### PR TITLE
WIP MTL-1761 define string params in a reusable lib

### DIFF
--- a/boxes/ncn-common/files/scripts/common/create-ims-initrd.sh
+++ b/boxes/ncn-common/files/scripts/common/create-ims-initrd.sh
@@ -27,6 +27,8 @@
 set -e
 set -x
 
+. $(dirname $0)/dracut-params.sh
+
 echo "Generating initrd..."
 
 version_full=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-default)
@@ -37,10 +39,11 @@ version="$version_base-$version_suse-default"
 
 dracut \
 --force \
---omit 'cifs ntfs-3g btrfs nfs fcoe iscsi modsign fcoe-uefi nbd dmraid multipath dmsquash-live-ntfs' \
---omit-drivers 'ecb md5 hmac' \
---add 'mdraid' \
---force-add 'dmsquash-live livenet mdraid' \
+--omit "${OMIT[@]}" \
+--omit-drivers "${OMIT_DRIVERS[@]}" \
+--add "${ADD[@]}" \
+--force-add "${FORCE_ADD[@]}" \
+--install "${INSTALL[@]}" \
 --kver ${version} \
 --no-hostonly \
 --no-hostonly-cmdline \

--- a/boxes/ncn-common/files/scripts/common/create-kis-artifacts.sh
+++ b/boxes/ncn-common/files/scripts/common/create-kis-artifacts.sh
@@ -29,6 +29,8 @@
 
 set -ex
 
+. $(dirname $0)/dracut-params.sh
+
 mkdir -p /mnt/squashfs /squashfs
 mount -o bind / /mnt/squashfs
 
@@ -48,13 +50,13 @@ if [[ "$1" != "squashfs-only" ]]; then
   mount --bind /dev /mnt/squashfs/dev
   mount --bind /sys /mnt/squashfs/sys
   mount --bind /var /mnt/squashfs/var
-  [ -f /var/adm/autoinstall/cache ] && rm -rf /var/adm/autoinstall/cache || echo >&2 'Could not remove autoinstall/cache!'
+  [ -f /var/adm/autoinstall/cache ] && rm -rf /var/adm/autoinstall/cache
   chroot /mnt/squashfs /bin/bash -c "dracut --xz --force \
-    --omit 'cifs ntfs-3g btrfs nfs fcoe iscsi modsign fcoe-uefi nbd dmraid multipath dmsquash-live-ntfs' \
-    --omit-drivers 'ecb md5 hmac' \
-    --add 'mdraid' \
-    --force-add 'dmsquash-live livenet mdraid' \
-    --install 'rmdir wipefs sgdisk vgremove less' \
+    --omit "${OMIT[@]}" \
+    --omit-drivers "${OMIT_DRIVERS[@]}" \
+    --add "${ADD[@]}" \
+    --force-add "${FORCE_ADD[@]}" \
+    --install "${INSTALL[@]}" \
     --persistent-policy by-label --show-modules --ro-mnt --no-hostonly --no-hostonly-cmdline \
     --kver ${version} \
     --printsize \

--- a/boxes/ncn-common/files/scripts/common/dracut-params.sh
+++ b/boxes/ncn-common/files/scripts/common/dracut-params.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+
+export OMIT=( "btrfs" "cifs" "dmraid" "dmsquash-live-ntfs" "fcoe" "fcoe-uefi" "iscsi" "modsign" "multipath" "nbd" "nfs" "ntfs-3g" )
+export OMIT_DRIVERS=( "ecb" "hmac" "md5" )
+export ADD=( "mdraid" )
+export FORCE_ADD=( "dmsquash-live" "livenet" "mdraid" )
+export INSTALL=( "less" "rmdir" "sgdisk" "vgremove" "wipefs" )
+


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1761

##### Issue Type
<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The new `dracut-params.sh` can be sourced to get common values, this replaces the duplicated hardcodes for:
- `--omit`
- `--omit-drivers`
- `--add`
- `--force-add`
- `--install`

This PR also updates `create-kis-artifacts.sh` and `create-ims-initrd.sh` to use the new library.

#### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
