### PR TITLE
MTL-1790 Fallout

### DIFF
--- a/boxes/ncn-common/common.pkr.hcl
+++ b/boxes/ncn-common/common.pkr.hcl
@@ -152,6 +152,13 @@ build {
 
   provisioner "shell" {
     inline = [
+      "bash -c '. /srv/cray/csm-rpms/scripts/rpm-functions.sh; install-packages /srv/cray/csm-rpms/packages/node-image-non-compute-common/google.packages'"]
+    valid_exit_codes = [0, 123]
+    only = ["googlecompute.ncn-common"]
+  }
+
+  provisioner "shell" {
+    inline = [
       "bash -c '. /srv/cray/csm-rpms/scripts/rpm-functions.sh; install-packages /srv/cray/csm-rpms/packages/node-image-non-compute-common/metal.packages'"]
     valid_exit_codes = [0, 123]
     only = ["qemu.ncn-common", "virtualbox-ovf.ncn-common"]

--- a/boxes/ncn-common/provisioners/common/install.sh
+++ b/boxes/ncn-common/provisioners/common/install.sh
@@ -96,22 +96,6 @@ systemctl enable --now goss-servers
 
 
 # Make virtualenv available to all contexts and teams.
-pip3 install virtualenv
-
-kubernetes_version="1.20.13-0"
-echo "Ensuring that the kubernetes package repo exists in zypper"
-if ! zypper repos | grep google-kubernetes; then
-  zypper addrepo --gpgcheck-strict --refresh https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64 google-kubernetes
-fi
-echo "Ensuring that we have the necessary gpg keys from google-kubernetes repo"
-rpm --import https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-rpm --import https://packages.cloud.google.com/yum/doc/yum-key.gpg
-curl -o /tmp/apt-key.gpg.asc https://packages.cloud.google.com/yum/doc/apt-key.gpg.asc
-echo "" >> /tmp/apt-key.gpg.asc
-rpm --import /tmp/apt-key.gpg.asc
-zypper refresh google-kubernetes
-zypper install -y kubectl-${kubernetes_version}
-zypper -n removerepo google-kubernetes || true
-
 pip3 install --upgrade pip
+pip3 install virtualenv
 pip3 install requests

--- a/boxes/ncn-common/provisioners/google/setup.sh
+++ b/boxes/ncn-common/provisioners/google/setup.sh
@@ -9,9 +9,7 @@ echo "activate public cloud module"
 product=$(SUSEConnect --list-extensions | grep -o "sle-module-public-cloud.*")
 [[ -n "$product" ]] && SUSEConnect -p "$product"
 
-echo "install guest environment packages"
-zypper refresh
-zypper install -y google-guest-{agent,configs,oslogin} google-osconfig-agent
+echo "Enable guest environment services"
 systemctl enable /usr/lib/systemd/system/google-*
 
 echo "Modifying DNS to use Cray DNS servers..."

--- a/boxes/ncn-node-images/kubernetes/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/kubernetes/provisioners/common/install.sh
@@ -36,7 +36,7 @@ mkdir -p /etc/cray/kubernetes/flexvolume
 # below are related to hostPath usage that should exist before k8s resources attempt to use them
 mkdir -p /opt/cray/tbd
 mkdir -p /var/run/sds
-
+echo "${KUBERNETES_PULL_VERSION}" > /etc/cray/kubernetes/version
 
 echo "Installing etcd binaries"
 mkdir -p /tmp/etcd

--- a/boxes/pit-common/pit-common.pkr.hcl
+++ b/boxes/pit-common/pit-common.pkr.hcl
@@ -148,6 +148,13 @@ build {
 
   provisioner "shell" {
     inline = [
+      "bash -c '. /srv/cray/csm-rpms/scripts/rpm-functions.sh; install-packages /srv/cray/csm-rpms/packages/node-image-non-compute-common/google.packages'"]
+    valid_exit_codes = [0, 123]
+    only = ["googlecompute.pit-common"]
+  }
+
+  provisioner "shell" {
+    inline = [
       "bash -c '. /srv/cray/csm-rpms/scripts/rpm-functions.sh; install-packages /srv/cray/csm-rpms/packages/cray-pre-install-toolkit/firmware.packages'"]
     valid_exit_codes = [0, 123]
     only = ["qemu.pit-common", "virtualbox-ovf.pit-common"]

--- a/boxes/pit-common/provisioners/google/setup.sh
+++ b/boxes/pit-common/provisioners/google/setup.sh
@@ -9,9 +9,7 @@ echo "activate public cloud module"
 product=$(SUSEConnect --list-extensions | grep -o "sle-module-public-cloud.*")
 [[ -n "$product" ]] && SUSEConnect -p "$product"
 
-echo "install guest environment packages"
-zypper refresh
-zypper install -y google-guest-{agent,configs,oslogin} google-osconfig-agent
+echo "Enable guest environment services"
 systemctl enable /usr/lib/systemd/system/google-*
 
 echo "Modifying DNS to use Cray DNS servers..."

--- a/vendor/github.com/Cray-HPE/csm-rpms/Jenkinsfile.github
+++ b/vendor/github.com/Cray-HPE/csm-rpms/Jenkinsfile.github
@@ -44,6 +44,7 @@ pipeline {
         sh """
           ./scripts/update-package-versions.sh -p packages/node-image-non-compute-common/base.packages --validate --suffix ${env.SUFFIX}
           ./scripts/update-package-versions.sh -p packages/node-image-non-compute-common/cms.packages --validate --suffix ${env.SUFFIX}
+          ./scripts/update-package-versions.sh -p packages/node-image-non-compute-common/google.packages --validate --suffix ${env.SUFFIX}
           ./scripts/update-package-versions.sh -p packages/node-image-non-compute-common/metal.packages --validate --suffix ${env.SUFFIX}
         """
       }

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/google.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/google.packages
@@ -1,0 +1,4 @@
+google-guest-agent=20220204.00-150000.1.26.1
+google-guest-configs=20220211.00-150000.1.19.1
+google-guest-oslogin=20220205.00-150000.1.27.1
+google-osconfig-agent=20220209.00-150000.1.17.1


### PR DESCRIPTION
Create /etc/cray/kubernetes/version with the KUBERNETES_PULL_VERSION variable. This file is necessary for kubernetes-cloudinit.sh for creating kubeadm.yaml. This file might be used in other places, so this change ensures that the version file still exists.


Without this change the `kubernetesVersion:` is incorrect in the kubeadm.yaml file:
```yaml
ncn-m002:~ # cat /etc/cray/kubernetes/kubeadm.yaml
---
apiVersion: kubeadm.k8s.io/v1beta2
kind: InitConfiguration
certificateKey: "ce28c44b12f1231038558a2218d2ca10c674c132fd9777b6419fd5806eda4456"
localAPIEndpoint:
  advertiseAddress: "10.252.1.5"
  bindPort: 6443
---
apiVersion: kubeadm.k8s.io/v1beta2
kind: ClusterConfiguration
kubernetesVersion: "v"
certificatesDir: /etc/kubernetes/pki
clusterName: kubernetes
controlPlaneEndpoint: "10.252.1.2:6442"
dns:
  type: CoreDNS
imageRepository: "artifactory.algol60.net/csm-docker/stable/k8s.gcr.io"
networking:
  dnsDomain: cluster.local
  podSubnet: "10.32.0.0/12"
  serviceSubnet: "10.16.0.0/12"
etcd:
  external:
    caFile: "/etc/kubernetes/pki/etcd/ca.crt"
    certFile: "/etc/kubernetes/pki/apiserver-etcd-client.crt"
    keyFile: "/etc/kubernetes/pki/apiserver-etcd-client.key"
    endpoints:
    - https://127.0.0.1:2381
apiServer:
  certSANs:
  - 10.252.1.2
  - 10.252.1.5
  extraArgs:
    runtime-config: "apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true"
    api-audiences: "api,istio-ca"
    oidc-issuer-url: "https://api-gw-service-nmn.local/keycloak/realms/shasta"
    oidc-client-id: "kubernetes-api-oidc-client"
    oidc-ca-file: "/etc/kubernetes/pki/oidc.pem"
    oidc-username-claim: "name"
    oidc-groups-claim: "groups"

controllerManager:
  extraArgs: {'flex-volume-plugin-dir': '/etc/cray/kubernetes/flexvolume'}
  extraVolumes:
    - name: cloud-config
      hostPath: /etc/cray/kubernetes/cloud-config
      mountPath: /etc/cray/kubernetes/cloud-config
      pathType: FileOrCreate
---
apiVersion: kubelet.config.k8s.io/v1beta1
kind: KubeletConfiguration
cgroupDriver: systemd
resolvConf: ""
maxPods: 200
---
apiVersion: kubeproxy.config.k8s.io/v1alpha1
kind: KubeProxyConfiguration
mode: ipvs
ipvs:
  strictARP: true
healthzBindAddress: 0.0.0.0:10256
```

This change came about during boot testing of #326, that PR was prematurely merged.
