### PR TITLE
MTL-1796 update pit common

### DIFF
--- a/boxes/pit-common/provisioners/common/install.sh
+++ b/boxes/pit-common/provisioners/common/install.sh
@@ -57,14 +57,6 @@ systemctl enable wickedd-nanny.service
 systemctl set-default multi-user.target
 
 #======================================
-# Install kubectl on LiveCD
-#--------------------------------------
-kubectl_version="1.19.9"
-echo "Installing kubectl"
-curl -L https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl
-chmod a+x /usr/local/bin/kubectl
-
-#======================================
 # Add custom aliases and environment
 # variables
 #--------------------------------------

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
@@ -39,6 +39,7 @@ iproute2-bash-completion=5.3-5.5.1
 iproute2=5.3-5.5.1
 iputils=s20161105-8.3.1
 jq=1.6-3.3.1
+kubectl=1.21.12-0
 less=530-3.3.2
 lshw=B.02.19.2+git.20210619-3.9.1
 lsof=4.91-1.11

--- a/vendor/github.com/Cray-HPE/csm-rpms/repos/suse.template.repos
+++ b/vendor/github.com/Cray-HPE/csm-rpms/repos/suse.template.repos
@@ -80,5 +80,6 @@ https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifac
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/sles-mirror/Backports/SLE-15-SP2_x86_64/standard?auth=basic                                 SUSE-Backports-SLE-15-SP2-x86_64                                      -g -p 89  suse/Backports-SLE/15-SP2/x86_64/standard
 
 # cephadm, ceph-common, and libfmt7
-https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/openSUSE:Backports:SLE-15-SP3/step/                                         openSUSE-Backports-SLE-15-SP3                                         -g -p 89  step/
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/openSUSE:Backports:SLE-15-SP3/step/                                         openSUSE-Backports-SLE-15-SP3-step                                         -g -p 89  step/
+https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/openSUSE:Backports:SLE-15-SP3/standard/                                     openSUSE-Backports-SLE-15-SP3-standard                                         -g -p 89  standard/
 https://${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN}@artifactory.algol60.net/artifactory/opensuse-mirror/filesystems:ceph/openSUSE_Leap_15.3/                                        filesystems-ceph                                                      -g -p 89  openSUSE_Leap_15.3/


### PR DESCRIPTION
This updates the LiveCD, pulling kubectl in via csm-rpms instead of an ad-hoc install.

The ensures kubectl is the same version, assuming it's updated in csm-rpms appropriately.

This pairs with:
- https://github.com/Cray-HPE/cray-pre-install-toolkit/pull/35
- https://github.com/Cray-HPE/csm-rpms/pull/452


This also brings in an ancillary change: https://github.com/Cray-HPE/csm-rpms/pull/453