### PR TITLE
MTL-1798 Ensure lvcreate clobbers any old signatures

### DIFF
--- a/boxes/ncn-node-images/kubernetes/files/resources/metal/cloud.cfg.d/00_metalfs_lvm.cfg
+++ b/boxes/ncn-node-images/kubernetes/files/resources/metal/cloud.cfg.d/00_metalfs_lvm.cfg
@@ -4,4 +4,4 @@
 bootcmd:
     - [cloud-init-per, once, create_PV, pvcreate, -ff, -y, -M, lvm2, /dev/md/AUX]
     - [cloud-init-per, once, create_VG, vgcreate, metalvg0, /dev/md/AUX]
-    - [cloud-init-per, once, create_LV_CRAYS3CACHE, lvcreate, -L, 200GB, -n, CRAYS3CACHE, metalvg0]
+    - [cloud-init-per, once, create_LV_CRAYS3CACHE, lvcreate, -L, 200GB, -n, CRAYS3CACHE, -y, metalvg0]

--- a/boxes/ncn-node-images/storage-ceph/files/resources/metal/cloud.cfg.d/00_metalfs_lvm.cfg
+++ b/boxes/ncn-node-images/storage-ceph/files/resources/metal/cloud.cfg.d/00_metalfs_lvm.cfg
@@ -4,6 +4,6 @@
 bootcmd:
     - [cloud-init-per, once, create_PV, pvcreate, -ff, -y, -M, lvm2, /dev/md/AUX]
     - [cloud-init-per, once, create_VG, vgcreate, metalvg0, /dev/md/AUX]
-    - [cloud-init-per, once, create_LV_CEPHETC, lvcreate, -L, 10GB, -n, CEPHETC, metalvg0]
-    - [cloud-init-per, once, create_LV_CEPHVAR, lvcreate, -L, 60GB, -n, CEPHVAR, metalvg0]
-    - [cloud-init-per, once, create_LV_CONTAIN, lvcreate, -L, 60GB, -n, CONTAIN, metalvg0]
+    - [cloud-init-per, once, create_LV_CEPHETC, lvcreate, -L, 10GB, -n, CEPHETC, -y, metalvg0]
+    - [cloud-init-per, once, create_LV_CEPHVAR, lvcreate, -L, 60GB, -n, CEPHVAR, -y, metalvg0]
+    - [cloud-init-per, once, create_LV_CONTAIN, lvcreate, -L, 60GB, -n, CONTAIN, -y, metalvg0]


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1798

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This passes `-y` to the `lvcreate` calls to ensure that if any signatures are found on an old LVM that they're clobbered.

This will remove/silence the benign (see JIRA) errors emitted during cloud-init runtime.

Example of this succeeding on a storage node:
```bash
  Physical volume "/dev/md/AUX" successfully created.
  Volume group "metalvg0" successfully created
  Wiping ext4 signature on /dev/metalvg0/CEPHETC.
  Logical volume "CEPHETC" created.
  Wiping ext4 signature on /dev/metalvg0/CEPHVAR.
  Logical volume "CEPHVAR" created.
  Wiping xfs signature on /dev/metalvg0/CONTAIN.
  Logical volume "CONTAIN" created.
```

Example of this succeeding on a kubernetes node:
```bash
   Physical volume "/dev/md/AUX" successfully created.
   Volume group "metalvg0" successfully created
   Wiping ext4 signature on /dev/metalvg0/CRAYS3CACHE.
   Logical volume "CRAYS3CACHE" created.
```

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
