### PR TITLE
CASMINST-4793 SECURITY SCRAMBLE

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -6,7 +6,7 @@ def buildGoogle = true
 def buildPIT = false // Toggle to True once we have ISOs working (MTL-1476)
 def rebuildBaseImage = false
 def rebuildCommonImage = true
-def sourceBuildVersion = "[RELEASE]" // Pulls the latest release
+def sourceBuildVersion = '\\\\[RELEASE\\\\]' // Pulls the latest release
 
 // Disable pr-merge builds; node-image pipeline doesn't use the PR images at all.
 if ( env.BRANCH_NAME ==~ ~"^PR-\\d+" ) {
@@ -30,7 +30,6 @@ pipeline {
     environment {
         NAME = "cray-node-image-build"
         DESCRIPTION = "Cray Management System Node Image Builder"
-        IS_STABLE = getBuildIsStable()
         VERSION = setImageVersion(commitHashShort: GIT_COMMIT[0..6])
         ARTIFACTS_DIRECTORY_BASE = "output-sles15-base"
         ARTIFACTS_DIRECTORY_COMMON = "output-ncn-common"
@@ -75,7 +74,7 @@ pipeline {
                     withCredentials([
                         usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
                     ]) {
-                        sh "curl -u${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} -O ${ISO_URL}"
+                        sh "curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} -O ${ISO_URL}"
                     }
                 }
             }
@@ -156,17 +155,21 @@ pipeline {
                         ]) {
                             script {
                                 // Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
-                                def source = "${ARTIFACTS_DIRECTORY_BASE}/sles15-base-${VERSION}.qcow2"
+                                def qcow = "sles15-base-${VERSION}.qcow2"
+                                def source = "${ARTIFACTS_DIRECTORY_BASE}/${qcow}"
                                 if (!params.rebuildBaseImage) {
                                     source = "${STABLE_BASE}/sles15-base/${params.sourceBuildVersion}/sles15-base-${params.sourceBuildVersion}.qcow2"
-                                    if (params.sourceBuildVersion != "[RELEASE]") {
+                                    if (params.sourceBuildVersion != "\\\\[RELEASE\\\\]") {
                                         // We must want a different build than latest
                                         source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, params.sourceBuildVersion)
                                     } else {
 
                                     }
                                 }
-                                def arguments = "-only=qemu.ncn-common -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                dir('iso') {
+                                    sh "curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} \"${source}\" --output ${qcow}"
+                                }
+                                def arguments = "-only=qemu.ncn-common -var 'source_iso_uri='iso/${qcow} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(arguments, 'boxes/ncn-common/')
                                 publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_COMMON, VERSION)
                                 def props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
@@ -188,17 +191,21 @@ pipeline {
                         ]) {
                             script {
                                 // Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
-                                def source = "${ARTIFACTS_DIRECTORY_BASE}/sles15-base-${VERSION}.qcow2"
+                                def qcow = "sles15-base-${VERSION}.qcow2"
+                                def source = "${ARTIFACTS_DIRECTORY_BASE}/${qcow}"
                                 if (!params.rebuildBaseImage) {
-                                    source = "${STABLE_BASE}/sles15-base/${params.sourceBuildVersion}/sles15-base-${params.sourceBuildVersion}.qcow2"
-                                    if (params.sourceBuildVersion != "[RELEASE]") {
+                                    source = "https://${STABLE_BASE}/sles15-base/${params.sourceBuildVersion}/sles15-base-${params.sourceBuildVersion}.qcow2"
+                                    if (params.sourceBuildVersion != "\\\\[RELEASE\\\\]") {
                                         // We must want a different build than latest
                                         source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, params.sourceBuildVersion)
                                     } else {
 
                                     }
                                 }
-                                def arguments = "-only=qemu.pit-common -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                dir("${env.ARTIFACTS_DIRECTORY_BASE}") {
+                                    sh "curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} \"${source}\" --output ${qcow}"
+                                }
+                                def arguments = "-only=qemu.pit-common -var 'source_iso_uri='iso/${qcow} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(arguments, 'boxes/pit-common/')
                                 publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_PIT, VERSION)
                                 def props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
@@ -229,7 +236,7 @@ pipeline {
                                 def googleSourceArtifact = "vshasta-sles15-base-${VERSION}"
                                 def googleSourceImageFamily = "vshasta-sles15-base"
                                 if (!params.rebuildBaseImage) {
-                                    if (params.sourceBuildVersion != "[RELEASE]") {
+                                    if (params.sourceBuildVersion == "\\\\[RELEASE\\\\]") {
                                         // We must want a different build than latest
                                         googleSourceArtifact = nodeImageHelpers.getGoogleCloudSourceArtifactFromId(googleSourceImageFamily, params.sourceBuildVersion)
                                     } else {
@@ -240,7 +247,6 @@ pipeline {
                                         )
                                     }
                                 }
-
                                 def googleArguments = "-only=googlecompute.ncn-common -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(googleArguments, 'boxes/ncn-common/')
                             }
@@ -266,7 +272,7 @@ pipeline {
                                 def googleSourceArtifact = "vshasta-sles15-base-${VERSION}"
                                 googleSourceImageFamily = "vshasta-sles15-base"
                                 if (!params.rebuildBaseImage) {
-                                    if (params.sourceBuildVersion != "[RELEASE]") {
+                                    if (params.sourceBuildVersion != "\\\\[RELEASE\\\\]") {
                                         // We must want a different build than latest
                                         googleSourceArtifact = nodeImageHelpers.getGoogleCloudSourceArtifactFromId(googleSourceImageFamily, params.sourceBuildVersion)
                                     } else {
@@ -277,7 +283,6 @@ pipeline {
                                         )
                                     }
                                 }
-
                                 def googleArguments = "-only=googlecompute.pit-common -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(googleArguments, 'boxes/pit-common/')
                             }
@@ -302,17 +307,21 @@ pipeline {
                         ]) {
                             script {
                                 // Did we build common? If YES, just use the RC image we built. If NO then use the latest non-RC
-                                def source = "${ARTIFACTS_DIRECTORY_COMMON}/ncn-common-${VERSION}.qcow2"
+                                def qcow = "ncn-common-${VERSION}.qcow2"
+                                def source = "${ARTIFACTS_DIRECTORY_COMMON}/${qcow}"
                                 if (!params.rebuildCommonImage) {
-                                    source = "${STABLE_BASE}/ncn-common/${params.sourceBuildVersion}/ncn-common-${params.sourceBuildVersion}.qcow2"
-                                    if (params.sourceBuildVersion != "[RELEASE]") {
+                                    source = "https://${STABLE_BASE}/ncn-common/${params.sourceBuildVersion}/ncn-common-${params.sourceBuildVersion}.qcow2"
+                                    if (params.sourceBuildVersion != "\\\\[RELEASE\\\\]") {
                                         // We must want a different build than latest
                                         source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, params.sourceBuildVersion)
                                     } else {
 
                                     }
                                 }
-                                def arguments = "-only=qemu.* -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                dir('iso') {
+                                    sh "curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} \"${source}\" --output ${qcow}"
+                                }
+                                def arguments = "-only=qemu.* -var 'source_iso_uri='iso/${qcow} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
                                 publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_K8S, env.VERSION)
                                 publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_CEPH, env.VERSION)
@@ -340,7 +349,7 @@ pipeline {
                                 def googleSourceArtifact = "vshasta-ncn-common-${VERSION}"
                                 def googleSourceImageFamily = "vshasta-ncn-common"
                                 if (!params.rebuildCommonImage) {
-                                    if (params.sourceBuildVersion != "[RELEASE]") {
+                                    if (params.sourceBuildVersion != "\\\\[RELEASE\\\\]") {
                                         // We must want a different build than latest
                                         googleSourceArtifact = nodeImageHelpers.getGoogleCloudSourceArtifactFromId(googleSourceImageFamily, params.sourceBuildVersion)
                                     } else {


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes CASMINST-4793

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
csm-images requires authentication to read. This change downloads the base images to a local directory using curl. Curl was used because packer can't handle authentication headers.

This change is required in order to build NCN images.

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [x] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
