### PR TITLE
MTL-1799 SECURITY SCRAMBLE

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -27,7 +27,6 @@ pipeline {
     environment {
         NAME = "cray-node-image-build"
         DESCRIPTION = "Cray Management System Node Image Builder"
-        IS_STABLE = getBuildIsStable()
         VERSION = setImageVersion(commitHashShort: GIT_COMMIT[0..6])
         ARTIFACTS_DIRECTORY_BASE = "output-sles15-base"
         ARTIFACTS_DIRECTORY_COMMON = "output-ncn-common"
@@ -67,7 +66,7 @@ pipeline {
                     withCredentials([
                         usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
                     ]) {
-                        sh "curl -u${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} -O ${ISO_URL}"
+                        sh "curl -f -u ${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} -O ${ISO_URL}"
                     }
                 }
             }
@@ -144,9 +143,14 @@ pipeline {
 							usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
 						]) {
 							script {
-								// If we didn't rebuild in this build, then always grab latest stable base.
-								def source = params.rebuildBaseImage ? "${ARTIFACTS_DIRECTORY_BASE}/sles15-base-${VERSION}.qcow2" : "${STABLE_BASE}/sles15-base/[RELEASE]/sles15-base-[RELEASE].qcow2"
-								def arguments = "-only=qemu.ncn-common -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                def qcow = "sles15-base-${VERSION}.qcow2"
+                                def source = params.rebuildBaseImage ? "${ARTIFACTS_DIRECTORY_BASE}/sles15-base-${VERSION}.qcow2" : "${STABLE_BASE}/sles15-base/[RELEASE]/sles15-base-[RELEASE].qcow2"
+                                if (params.rebuildBaseImage == false) {
+                                    dir("${env.ARTIFACTS_DIRECTORY_BASE}") {
+                                        sh "curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} \"${source}\" --output ${qcow}"
+                                    }
+                                }
+								def arguments = "-only=qemu.ncn-common -var 'source_iso_uri='${env.ARTIFACTS_DIRECTORY_BASE}/${qcow} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
 								publishCsmImages.build(arguments, 'boxes/ncn-common/')
 								publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_COMMON, VERSION)
 								def props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
@@ -155,28 +159,6 @@ pipeline {
 						}
 					}
 				}
-// 				stage('QEMU PIT Common') {
-// 					when {
-// 						expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-// 						expression { params.rebuildCommonImage }
-// 					}
-// 					steps {
-// 						withCredentials([
-// 							string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-// 							usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
-// 						]) {
-// 							script {
-// 								// If we didn't rebuild in this build, then always grab latest stable base.
-// 								def source = params.rebuildBaseImage ? "${ARTIFACTS_DIRECTORY_BASE}/sles15-base-${VERSION}.qcow2" : "${STABLE_BASE}/sles15-base/[RELEASE]/sles15-base-[RELEASE].qcow2"
-// 								def arguments = "-only=qemu.pit-common -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-// 								publishCsmImages.build(arguments, 'boxes/pit-common/')
-// 								publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_PIT, VERSION)
-// 								def props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
-// 								publishCsmImages(pattern: ARTIFACTS_DIRECTORY_PIT, imageName: 'pit-common', version: env.VERSION, props: props)
-// 							}
-// 						}
-// 					}
-// 				}
 			}
 		}
 		stage("Build GCP Common and PIT") {
@@ -212,37 +194,6 @@ pipeline {
 						}
 					}
 				}
-// 				stage('GCP PIT Common') {
-// 					when {
-// 						expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
-// 						expression { params.rebuildCommonImage }
-// 						expression { params.buildGoogle }
-// 					}
-// 					steps {
-// 						withCredentials([
-// 							string(credentialsId: 'sles15-initial-root-password', variable: 'SLES15_INITIAL_ROOT_PASSWORD'),
-// 							usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN'),
-// 							file(credentialsId: 'google-image-manager', variable: 'GOOGLE_APPLICATION_CREDENTIALS'),
-// 							file(credentialsId: 'google-image-manager', variable: 'GOOGLE_CLOUD_SA_KEY')
-// 						]) {
-// 							script {
-// 								// Did we build base? If YES, just use the RC image we built. If NO then use the latest non-RC
-// 								def googleSourceArtifact = params.rebuildBaseImage ? "vshasta-sles15-base-${VERSION}" : ""
-// 								if (googleSourceArtifact == "") {
-// 									googleSourceArtifact = getGoogleCloudSourceArtifact(
-// 										googleCloudSaKey: env.GOOGLE_CLOUD_SA_KEY,
-// 										googleCloudProject: params.sourceProjectId,
-// 										googleCloudFamily: 'vshasta-sles15-base',
-// 										fullUrl: false
-// 									)
-// 								}
-//
-// 								def googleArguments = "-only=googlecompute.pit-common -var 'google_source_image_name=${googleSourceArtifact}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'artifact_version=${VERSION}'"
-// 								publishCsmImages.build(googleArguments, 'boxes/pit-common/')
-// 							}
-// 						}
-// 					}
-// 				}
             }
         }
         // Always build.
@@ -260,8 +211,14 @@ pipeline {
                             usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
                         ]) {
                             script {
+                                def qcow = "ncn-common-${VERSION}.qcow2"
                                 def source = params.rebuildCommonImage ? "${ARTIFACTS_DIRECTORY_COMMON}/ncn-common-${VERSION}.qcow2" : "${STABLE_BASE}/ncn-common/[RELEASE]/ncn-common-[RELEASE].qcow2"
-                                def arguments = "-only=qemu.kubernetes -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                if (params.rebuildCommonImage == false) {
+                                    dir("${env.ARTIFACTS_DIRECTORY_COMMON}") {
+                                        sh "curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} \"${source}\" --output ${qcow}"
+                                    }
+                                }
+                                def arguments = "-only=qemu.kubernetes -var 'source_iso_uri='${env.ARTIFACTS_DIRECTORY_COMMON}/${qcow} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
                                 publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_K8S}", env.VERSION)
                                 def props = "build.number=${VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${source}"
@@ -311,8 +268,14 @@ pipeline {
                             usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
                         ]) {
                             script {
+                                def qcow = "ncn-common-${VERSION}.qcow2"
                                 def source = params.rebuildCommonImage ? "${ARTIFACTS_DIRECTORY_COMMON}/ncn-common-${VERSION}.qcow2" : "${STABLE_BASE}/ncn-common/[RELEASE]/ncn-common-[RELEASE].qcow2"
-                                def arguments = "-only=qemu.storage-ceph -var 'source_iso_uri='${source} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                if (params.rebuildCommonImage == false) {
+                                    dir("${env.ARTIFACTS_DIRECTORY_COMMON}") {
+                                    sh "curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} \"${source}\" --output ${qcow}"
+                                    }
+                                }
+                                def arguments = "-only=qemu.storage-ceph -var 'source_iso_uri='${env.ARTIFACTS_DIRECTORY_COMMON}/${qcow} -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
                                 sh "ls -lhR ${ARTIFACTS_DIRECTORY_CEPH}"
                                 publishCsmImages.prepareArtifacts(ARTIFACTS_DIRECTORY_CEPH, VERSION)


### PR DESCRIPTION
#### Summary and Scope
<!--- Pick one below and delete the rest -->

- Fixes MTL-1799
- Relates to CASMINST-4793

##### Issue Type
<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
    
csm-images now requires authentication to read due to the CASMINST-4793 security scramble. This change downloads the base images to a local directory using curl. Curl was used because packer can't handle authentication headers.

**This change is required to fix NCN image builds.**

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [x] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
#### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
