### PR TITLE
added regex in goss test for no root password check

### DIFF
--- a/boxes/ncn-node-images/kubernetes/files/tests/common/goss-image-common.yaml
+++ b/boxes/ncn-node-images/kubernetes/files/tests/common/goss-image-common.yaml
@@ -23,7 +23,7 @@ command:
 service:
   chronyd:
     enabled: true
-    running: false
+    running: true
   ca-certificates:
     enabled: true
     running: false

--- a/boxes/ncn-node-images/kubernetes/files/tests/common/goss-image-common.yaml
+++ b/boxes/ncn-node-images/kubernetes/files/tests/common/goss-image-common.yaml
@@ -16,7 +16,7 @@ command:
     exit-status: 0
     exec: "grep root /etc/shadow"
     stdout:
-    - root:*:18969::::::
+    - "/^root:\\*:\\d*::::::$/"
     stderr: []
     timeout: 2000 # in milliseconds
     skip: false

--- a/boxes/ncn-node-images/kubernetes/files/tests/metal/goss-image-common.yaml
+++ b/boxes/ncn-node-images/kubernetes/files/tests/metal/goss-image-common.yaml
@@ -24,6 +24,7 @@
 service:
   metalfs:
     enabled: true
+    enabled: false
   cloud-config:
     enabled: true
     running: false

--- a/boxes/ncn-node-images/kubernetes/files/tests/metal/goss-image-common.yaml
+++ b/boxes/ncn-node-images/kubernetes/files/tests/metal/goss-image-common.yaml
@@ -24,7 +24,7 @@
 service:
   metalfs:
     enabled: true
-    enabled: false
+    running: false
   cloud-config:
     enabled: true
     running: false

--- a/boxes/ncn-node-images/storage-ceph/files/tests/common/goss-image-common.yaml
+++ b/boxes/ncn-node-images/storage-ceph/files/tests/common/goss-image-common.yaml
@@ -23,7 +23,7 @@ command:
 service:
   chronyd:
     enabled: true
-    running: false
+    running: true
   ca-certificates:
     enabled: true
     running: false
@@ -73,5 +73,5 @@ service:
     enabled: false
     running: false
   spire-agent:
-    enabled: true
+    enabled: false
     running: false

--- a/boxes/ncn-node-images/storage-ceph/files/tests/common/goss-image-common.yaml
+++ b/boxes/ncn-node-images/storage-ceph/files/tests/common/goss-image-common.yaml
@@ -16,7 +16,7 @@ command:
     exit-status: 0
     exec: "grep root /etc/shadow"
     stdout:
-    - root:*:18969::::::
+    - "/^root:\\*:\\d*::::::$/"
     stderr: []
     timeout: 2000 # in milliseconds
     skip: false


### PR DESCRIPTION
#### Summary and Scope

- Fixes unmarshal errors in goss test for ensuring that no root password exists in /etc/shadow on ncn images

##### Issue Type

- Bugfix Pull Request

#### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on metal (e.g. an internal system, with hardware) (x) (if yes, please include results or a description of the test)
- [ ] I tested this on vshasta (if yes, please include results or a description of the test)
 
#### Idempotency
 
goss tests are idempotent
 