### PR TITLE
MTL-1288 Auto-wipe Fix

### DIFF
--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-kubernetes/metal.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-kubernetes/metal.packages
@@ -1,4 +1,4 @@
-dracut-metal-dmk8s=1.7.1-1
-dracut-metal-luksetcd=1.7.1-1
+dracut-metal-dmk8s=2.0.0-1
+dracut-metal-luksetcd=2.0.0-1
 haproxy=2.0.14-bp152.1.1
 keepalived=2.0.19-bp152.1.9

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/metal.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/metal.packages
@@ -1,6 +1,6 @@
 biosdevname=0.7.3-5.3.1
 dracut-kiwi-live=9.24.16-3.47.1
-dracut-metal-mdsquash=1.10.1-1
+dracut-metal-mdsquash=2.0.0-1
 grub2-branding-SLE=15-33.3.1
 grub2-i386-pc=2.04-150300.22.15.2
 grub2-x86_64-efi=2.04-150300.22.15.2

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/resources/metal/mdadm.conf
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/resources/metal/mdadm.conf
@@ -1,2 +1,2 @@
-# HOMEHOST <ignore> 'do not include any hostname info in the RAID's ID, just use the FSLabel'
-HOMEHOST <ignore>
+# HOMEHOST <none> 'do not include any hostname info in the RAID's ID, just use the FSLabel'
+HOMEHOST <none>


### PR DESCRIPTION
This brings in two vendor updates:
- `mdadm.conf` change from https://github.com/Cray-HPE/metal-provision/pull/8
- `dracut-metal` RPMs from https://github.com/Cray-HPE/csm-rpms/pull/464

The changes fix the MTL-1288 bug for the auto-wipe.