### PR TITLE
Latest 0.3.10 Release

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -74,7 +74,7 @@ pipeline {
                     withCredentials([
                         usernamePassword(credentialsId: 'artifactory-algol60', usernameVariable: 'ARTIFACTORY_USER', passwordVariable: 'ARTIFACTORY_TOKEN')
                     ]) {
-                        sh "curl -u ${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} -O ${ISO_URL}"
+                        sh "curl -f -u ${ARTIFACTORY_USER}:${ARTIFACTORY_TOKEN} -O ${ISO_URL}"
                     }
                 }
             }

--- a/boxes/ncn-node-images/kubernetes/files/tests/common/goss-image-common.yaml
+++ b/boxes/ncn-node-images/kubernetes/files/tests/common/goss-image-common.yaml
@@ -23,7 +23,7 @@ command:
 service:
   chronyd:
     enabled: true
-    running: false
+    running: true
   ca-certificates:
     enabled: true
     running: false

--- a/boxes/ncn-node-images/kubernetes/files/tests/common/goss-image-common.yaml
+++ b/boxes/ncn-node-images/kubernetes/files/tests/common/goss-image-common.yaml
@@ -16,7 +16,7 @@ command:
     exit-status: 0
     exec: "grep root /etc/shadow"
     stdout:
-    - root:*:18969::::::
+    - "/^root:\\*:\\d*::::::$/"
     stderr: []
     timeout: 2000 # in milliseconds
     skip: false

--- a/boxes/ncn-node-images/kubernetes/files/tests/metal/goss-image-common.yaml
+++ b/boxes/ncn-node-images/kubernetes/files/tests/metal/goss-image-common.yaml
@@ -24,6 +24,7 @@
 service:
   metalfs:
     enabled: true
+    enabled: false
   cloud-config:
     enabled: true
     running: false

--- a/boxes/ncn-node-images/kubernetes/files/tests/metal/goss-image-common.yaml
+++ b/boxes/ncn-node-images/kubernetes/files/tests/metal/goss-image-common.yaml
@@ -24,7 +24,7 @@
 service:
   metalfs:
     enabled: true
-    enabled: false
+    running: false
   cloud-config:
     enabled: true
     running: false

--- a/boxes/ncn-node-images/storage-ceph/files/tests/common/goss-image-common.yaml
+++ b/boxes/ncn-node-images/storage-ceph/files/tests/common/goss-image-common.yaml
@@ -23,7 +23,7 @@ command:
 service:
   chronyd:
     enabled: true
-    running: false
+    running: true
   ca-certificates:
     enabled: true
     running: false
@@ -73,5 +73,5 @@ service:
     enabled: false
     running: false
   spire-agent:
-    enabled: true
+    enabled: false
     running: false

--- a/boxes/ncn-node-images/storage-ceph/files/tests/common/goss-image-common.yaml
+++ b/boxes/ncn-node-images/storage-ceph/files/tests/common/goss-image-common.yaml
@@ -16,7 +16,7 @@ command:
     exit-status: 0
     exec: "grep root /etc/shadow"
     stdout:
-    - root:*:18969::::::
+    - "/^root:\\*:\\d*::::::$/"
     stderr: []
     timeout: 2000 # in milliseconds
     skip: false

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
@@ -1,13 +1,13 @@
 # CSM Packages
 apache2=2.4.51-150200.3.42.1
 canu=1.6.5-1
-craycli=0.52.0-1
+craycli=0.53.0-1
 dnsmasq=2.86-150100.7.20.1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-scripts=0.0.34-1
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
-loftsman=1.2.0-20211217162356_bf1bdb7
-manifestgen=1.3.5-1~development~9299ac1
+loftsman=1.2.0-1
+manifestgen=1.3.6-1
 
 # CSM METAL-team Packages
 cray-site-init=1.20.0-1
@@ -22,7 +22,7 @@ pit-nexus=1.1.4-1
 acl=2.2.52-4.3.1
 bash-completion=2.7-4.6.1
 bc=1.07.1-11.37
-binutils=2.37-150100.7.29.1
+binutils=2.37-150100.7.34.1
 bsdtar=3.4.2-2.24
 checkmedia=5.4-1.13
 chrony=4.1-150300.16.9.1

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-kubernetes/base.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-kubernetes/base.packages
@@ -3,8 +3,8 @@ cray-cmstools-crayctldeploy=1.3.3-1
 ipvsadm=1.29-4.3.1
 kubeadm=1.21.12-0
 kubelet=1.21.12-0
-loftsman=1.2.0-20211217162356_bf1bdb7
-manifestgen=1.3.5-1~development~9299ac1
+loftsman=1.2.0-1
+manifestgen=1.3.6-1
 platform-utils=1.2.9-1
 python3-boto3=1.18.7-23.4.1
 

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-kubernetes/metal.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-kubernetes/metal.packages
@@ -1,4 +1,4 @@
-dracut-metal-dmk8s=1.7.1-1
-dracut-metal-luksetcd=1.7.1-1
+dracut-metal-dmk8s=2.0.0-1
+dracut-metal-luksetcd=2.0.0-1
 haproxy=2.0.14-bp152.1.1
 keepalived=2.0.19-bp152.1.9

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/base.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/base.packages
@@ -7,12 +7,12 @@ cray-power-button=1.3.1-2.3_20220329162359__g0ddf9af
 # CSM
 cray-kubectl-hns-plugin=1.0.0-1
 cray-kubectl-kubelogin-plugin=1.25.1-1
-craycli=0.52.0-1
+craycli=0.53.0-1
 csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.34-1
 
 # CSM Testing Utils
-goss-servers=1.14.25-1
+goss-servers=1.14.26-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77
 hpe-csm-yq-package=3.4.1-20210615153837_40f15a6
 

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/metal.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/metal.packages
@@ -1,6 +1,6 @@
 biosdevname=0.7.3-5.3.1
 dracut-kiwi-live=9.24.16-3.47.1
-dracut-metal-mdsquash=1.10.1-1
+dracut-metal-mdsquash=2.0.0-1
 grub2-branding-SLE=15-33.3.1
 grub2-i386-pc=2.04-150300.22.15.2
 grub2-x86_64-efi=2.04-150300.22.15.2

--- a/vendor/github.com/Cray-HPE/csm-rpms/repos/cray.repos
+++ b/vendor/github.com/Cray-HPE/csm-rpms/repos/cray.repos
@@ -5,6 +5,4 @@ https://artifactory.algol60.net/artifactory/csm-rpms/hpe/stable/sle-15sp2/      
 
 https://arti.dev.cray.com/artifactory/sat-rpm-master-local/dev/master/sle15_sp2_ncn/                              cray-sat-sle-15sp2-x86_64-master                  --no-gpgcheck -p 89                   cray/sat/sle-15sp2/x86_64
 
-https://arti.dev.cray.com/artifactory/csm-rpm-stable-local/release/                                               cray-csm-rpm-stable-local-release                 --no-gpgcheck -p 89                   cray/csm/rpm/stable/local/release
-
 https://arti.dev.cray.com/artifactory/sdu-rpm-stable-local/release/img_oci-shasta-2.0/sle15_sp3_ncn/              sdu-rpm-stable-local                              --no-gpgcheck -p 89                   sdu-rpm-stable-local/release/2.0/sle15_sp3_ncn/

--- a/vendor/github.com/Cray-HPE/metal-provision/.github/workflows/lint.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/.github/workflows/lint.yml
@@ -1,0 +1,12 @@
+name: Ansible Lint # feel free to pick your own name
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Ansible Lint
+        uses: ansible-community/ansible-lint-action@v6.2.1
+

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-install/defaults/main.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-install/defaults/main.yml
@@ -1,0 +1,103 @@
+---
+services_common:
+  - name: ca-certificates.service
+    enabled: yes
+    state: stopped
+  - name: chronyd.service
+    enabled: yes
+    state: stopped
+  - name: getty@tty1.service
+    enabled: yes
+    state: started
+  - name: goss-servers
+    enabled: yes
+    state: started
+  - name: issue-generator.service
+    enabled: yes
+    state: stopped
+  - name: kdump-early.service
+    enabled: yes
+    state: stopped
+  - name: kdump.service
+    enabled: yes
+    state: stopped
+  - name: lldpad.service
+    enabled: yes
+    state: started
+  - name: multi-user.target
+    enabled: yes
+    state: started
+  - name: postfix.service
+    enabled: no
+    state: stopped
+  - name: purge-kernels.service
+    enabled: yes
+    state: stopped
+  - name: rasdaemon.service
+    enabled: yes
+    state: stopped
+  - name: rc-local.service
+    enabled: yes
+    state: stopped
+  - name: rollback.service
+    enabled: yes
+    state: stopped
+  - name: serial-getty@ttyS0.service
+    enabled: yes
+    state: stopped
+  - name: spire-agent.service
+    enabled: yes
+    state: stopped
+  - name: sshd.service
+    enabled: yes
+    state: started
+  - name: wicked.service
+    enabled: yes
+    state: started
+  - name: wickedd-auto4.service
+    enabled: yes
+    state: started
+  - name: wickedd-dhcp4.service
+    enabled: yes
+    state: started
+  - name: wickedd-dhcp6.service
+    enabled: yes
+    state: started
+  - name: wickedd-nanny.service
+    enabled: yes
+    state: started
+services_google:
+  - name: kdump-early.service
+    enabled: yes
+    state: stopped
+  - name: kdump.service
+    enabled: yes
+    state: stopped
+services_metal:
+  - name: ahslog
+    enabled: no
+    state: stopped
+  - name: amsd
+    enabled: no
+    state: stopped
+  - name: cpqFca
+    enabled: no
+    state: stopped
+  - name: cpqIde
+    enabled: no
+    state: stopped
+  - name: cpqScsi
+    enabled: no
+    state: stopped
+  - name: kdump-early.service
+    enabled: yes
+    state: started
+  - name: kdump.service
+    enabled: yes
+    state: started
+  - name: smad
+    enabled: no
+    state: stopped
+  - name: sysstat.service
+    enabled: yes
+    state: started

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-install/tasks/common.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-install/tasks/common.yml
@@ -1,24 +1,24 @@
 ---
 
-- name: symlink python3
+- name: Symlink python3 to python
   file:
     src: /usr/bin/python3
     dest: /usr/bin/python
     state: link
 
-- name: ensure /srv/cray/utilities locations are available for use system-wide
+- name: Ensure /srv/cray/utilities locations are available for use system-wide
   file:
     src: /srv/cray/utilities/common/craysys/craysys
     dest: /bin/craysys
     state: link
 
-- name: ensure craysys is executable
+- name: Ensure craysys is executable
   file:
     path: /srv/cray/utilities/common/craysys/craysys
     state: file
     mode: a+x
 
-- name: create cray.sh profile
+- name: Create cray.sh profile
   file:
     path: /etc/profile.d/cray.sh
     state: touch
@@ -26,13 +26,13 @@
     owner: root
     group: root
 
-- name: export cray path
+- name: Export cray path
   lineinfile:
     path: /etc/profile.d/cray.sh
     regexp: '^export PYTHONPATH='
     line: 'export PYTHONPATH="/srv/cray/utilities/common"'
 
-- name: create /etc/containers
+- name: Create /etc/containers
   file:
     path: /etc/containers
     state: directory
@@ -40,7 +40,7 @@
     owner: root
     group: root
 
-- name: create storage.conf
+- name: Create storage.conf
   file:
     path: /etc/containers/storage.conf
     state: touch
@@ -48,67 +48,25 @@
     owner: root
     group: root
 
-- name: configure podman so it will run with fuse-overlayfs
+- name: Configure podman so it will run with fuse-overlayfs
   lineinfile:
     path: /etc/containers/storage.conf
     regexp: '^#?mount_program ='
     line: 'mount_program = "/usr/bin/fuse-overlayfs"'
 
-- name: enable multi-user target
-  systemd:
-    name: multi-user.target
-    enabled: yes
-    masked: no
-
-- name: get current systemd default
+- name: Get current systemd default
   command: "systemctl get-default"
   changed_when: false
   register: systemdefault
 
-- name: set default to multi-user target
+- name: Set default to multi-user target
   command: "systemctl set-default multi-user.target"
   when: "'multi-user' not in systemdefault.stdout"
 
-- name: enable services
+- name: Setup Daemons
   systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - ca-certificates.service
-    - chronyd.service
-    - getty@tty1.service
-    - goss-servers
-    - issue-generator.service
-    - kdump-early.service
-    - kdump.service
-    - lldpad.service
-    - purge-kernels.service
-    - rasdaemon.service
-    - rc-local.service
-    - rollback.service
-    - serial-getty@ttyS0.service
-    - spire-agent.service
-    - sshd.service
-    - wicked.service
-    - wickedd-auto4.service
-    - wickedd-dhcp4.service
-    - wickedd-dhcp6.service
-    - wickedd-nanny.service
-
-# goss tests must be updated every time this list is altered
-- name: start services
-  systemd:
-    name: "{{ item }}"
-    state: started
-  with_items:
-    - goss-servers
-    - lldpad.service
-
-- name: disable postfix service
-  systemd:
-    name: "{{ item }}"
-    enabled: no
-    state: stopped
-  with_items:
-    - postfix.service
+    enabled: "{{ item.enabled }}"
+    name: "{{ item.name }}"
+    masked: "{{ item.masked | default(false) }}"
+    state: "{{ item.state }}"
+  with_items: "{{ services_common }}"

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-install/tasks/gcp.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-install/tasks/gcp.yml
@@ -1,1 +1,8 @@
 ---
+- name: Setup Daemons
+  systemd:
+    enabled: "{{ item.enabled }}"
+    name: "{{ item.name }}"
+    masked: "{{ item.masked | default(false) }}"
+    state: "{{ item.state }}"
+  with_items: "{{ services_google }}"

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-install/tasks/metal.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-install/tasks/metal.yml
@@ -11,34 +11,19 @@
   command: "/usr/lib64/sa/sa1 -S DISK 1 1"
   when: copy_sysstat_service.changed
 
-- name: enable sysstat service
-  systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - sysstat.service
-
 - name: copy mdadm.conf into place
   copy:
     remote_src: yes
     src: /srv/cray/resources/metal/mdadm.conf
     dest: /etc/mdadm.conf
 
-# Agentless Management Service only works on servers with iLO4/5.
-# Disable by default, enable during runtime.
-- name: disable Agentless Management Daemon
+- name: Daemons
   systemd:
-    name: "{{ item }}"
-    enabled: no
-    state: stopped
-  with_items:
-    - ahslog
-    - amsd
-    - cpqFca
-    - cpqIde
-    - cpqScsi
-    - smad
+    name: "{{ item.name }}"
+    enabled: "{{ item.enabled }}"
+    masked: "{{ item.masked | default(false) }}"
+    state: "{{ item.state }}"
+  with_items: "{{ services_metal }}"
 
 - name: configure dhcp settings
   lineinfile:

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/defaults/main.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/defaults/main.yml
@@ -1,0 +1,31 @@
+---
+services_google:
+  - name: google-guest-agent.service
+    enabled: yes
+    state: started
+  - name: google-osconfig-agent.service
+    enabled: yes
+    state: started
+  - name: google-oslogin-cache.service
+    enabled: yes
+    state: started
+  - name: google-oslogin-cache.timer
+    enabled: yes
+    state: started
+  - name: google-shutdown-scripts.service
+    enabled: yes
+    state: started
+  - name: google-startup-scripts.service
+    enabled: yes
+    state: started
+services_metal:
+  - name: cloud-init-oneshot
+    enabled: yes
+    state: stopped
+  - name: kdump-cray
+    enabled: yes
+    state: stopped 
+  - name: metal-iptables
+    enabled: no
+    state: stopped
+    

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/resources/metal/mdadm.conf
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/resources/metal/mdadm.conf
@@ -1,2 +1,2 @@
-# HOMEHOST <ignore> 'do not include any hostname info in the RAID's ID, just use the FSLabel'
-HOMEHOST <ignore>
+# HOMEHOST <none> 'do not include any hostname info in the RAID's ID, just use the FSLabel'
+HOMEHOST <none>

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/tests/common/goss-image-common.yaml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/tests/common/goss-image-common.yaml
@@ -26,10 +26,22 @@ file:
   /var/adm/autoinstall/cache:
     exists: false
 service:
+  ca-certificates:
+    enabled: true
+    running: false
+  ca-certificates:
+    enabled: true
+    running: false
+  chronyd:
+    enabled: true
+    running: false
   cloud-config:
     enabled: true
     running: false
-  cloud-init:
+  cloud-config:
+    enabled: true
+    running: false
+  cloud-final:
     enabled: true
     running: false
   cloud-final:
@@ -38,32 +50,32 @@ service:
   cloud-init-local:
     enabled: true
     running: false
-  ca-certificates:
-    enabled: true
-    running: false
-  issue-generator:
-    enabled: true
-    running: false
-  ca-certificates:
-    enabled: true
-    running: false
-  cloud-config:
+  cloud-init-local:
     enabled: true
     running: false
   cloud-init:
     enabled: true
     running: false
-  cloud-init-local:
+  cloud-init:
     enabled: true
     running: false
-  cloud-final:
+  getty@tty1:
     enabled: true
-    running: false
+    running: true
   goss-servers:
     enabled: true
     running: true
   issue-generator:
     enabled: true
+    running: false
+  issue-generator:
+    enabled: true
+    running: false
+  lldpad:
+    enabled: true
+    running: true
+  postfix:
+    enabled: false
     running: false
   purge-kernels:
     enabled: true
@@ -72,6 +84,9 @@ service:
     enabled: true
     running: false
   rollback:
+    enabled: true
+    running: false
+  spire-agent:
     enabled: true
     running: false
   sshd:
@@ -92,18 +107,3 @@ service:
   wickedd-nanny:
     enabled: true
     running: true
-  getty@tty1:
-    enabled: true
-    running: true
-  lldpad:
-    enabled: true
-    running: true
-  postfix:
-    enabled: false
-    running: false
-  chronyd:
-    enabled: true
-    running: false
-  spire-agent:
-    enabled: true
-    running: false

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/tests/metal/goss-image-common.yaml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/tests/metal/goss-image-common.yaml
@@ -6,11 +6,23 @@ service:
     enabled: true
     running: true
   amsd:
-      enabled: false
-      running: false
+    enabled: false
+    running: false
   ahslog:
-      enabled: false
-      running: false
+    enabled: false
+    running: false
   sma:
-      enabled: false
-      running: false
+    enabled: false
+    running: false
+  sysstat.service:
+    enabled: false
+    running: true
+  cpqFca:
+    enabled: false
+    running: false
+  cpqIde:
+    enabled: false
+    running: false
+  cpqScsi:
+    enabled: false
+    running: false

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/tasks/gcp.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/tasks/gcp.yml
@@ -19,18 +19,12 @@
     - google-guest-oslogin
     - google-osconfig-agent
 
-- name: enable google services and ensure they are not masked
+- name: Setup Daemons
   systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - google-guest-agent.service
-    - google-osconfig-agent.service
-    - google-oslogin-cache.service
-    - google-oslogin-cache.timer
-    - google-shutdown-scripts.service
-    - google-startup-scripts.service
+    name: "{{ item.name }}"
+    enabled: "{{ item.enabled }}"
+    masked: "{{ item.masked | default(false) }}"
+  with_items: "{{ services_google }}"
 
 - name: stub out network interface configuration files
   copy:

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/tasks/metal.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/tasks/metal.yml
@@ -12,23 +12,6 @@
     src: /srv/cray/resources/metal/systemd/
     dest: /usr/lib/systemd/system/
 
-- name: enable metal services and ensure they are not masked
-  systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - cloud-init-oneshot
-    - kdump-cray
-
-- name: disable services
-  systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - metal-iptables
-
 - name: add sshd_config for metal
   copy:
     remote_src: yes

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-team/defaults/main.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-team/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+services_common:
+  - name: cfs-state-reporter.service
+    enabled: yes
+    state: started
+  - name: cray-heartbeat.service
+    enabled: yes
+    state: started
+  - name: csm-node-identity.service
+    enabled: yes
+    state: started

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-team/tasks/common.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-team/tasks/common.yml
@@ -1,21 +1,11 @@
 ---
 
-- name: enable HPE CSM CMS Services
+- name: Setup Daemons
   systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - cfs-state-reporter.service
-
-- name: enable HPE Cray OS services
-  systemd:
-    name: "{{ item }}"
-    enabled: yes
-    masked: no
-  with_items:
-    - cray-heartbeat.service
-    - csm-node-identity.service
+    name: "{{ item.name }}"
+    enabled: "{{ item.enabled }}"
+    masked: "{{ item.masked | default(false) }}"
+  with_items: "{{ services_common }}"
 
 - name: rsyslog config to ensure the NCN OS logs are routed to SMF
   copy:


### PR DESCRIPTION
This includes the following commits:
- d11340f00 (HEAD -> develop, tag: 0.3.10-4, tag: 0.3.10, origin/develop, origin/MTL-1288, origin/HEAD, MTL-1288) Update "csm-rpms" from "git@github.com:Cray-HPE/csm-rpms.git@main"
- a9493b742 Squashed 'vendor/github.com/Cray-HPE/csm-rpms/' changes from 982cb3af2..865ec55b2
- ed3bd0f16 Update "metal-provision" from "git@github.com:Cray-HPE/metal-provision.git@v1.0.2"
- f059d7856 Squashed 'vendor/github.com/Cray-HPE/metal-provision/' changes from 4cc1fd9e5..43e9e3cb9
- 93e017435 Squashed 'vendor/github.com/Cray-HPE/csm-rpms/' changes from b6f19bb9e..982cb3af2
- 6c2d9ddb5 (tag: 0.3.10-3, origin/csm-rpms-update-2, csm-rpms-update-2) Update "csm-rpms" from "git@github.com:Cray-HPE/csm-rpms.git@main"
- 7d569f5ea (origin/root-goss-test-fix, root-goss-test-fix) modified goss test for kubernetes and ceph (chronyd / spire-agent)
- 74426862b added required attribute 'running: false'
- 84163a8d4 added required attribute 'running: false'
- 09a08230b added regex in goss test for no root password check
- c7a797b2d Squashed 'vendor/github.com/Cray-HPE/metal-provision/' changes from a52098c75..4cc1fd9e5
- b604b19b8 (tag: 0.3.10-2, origin/MTL-1800-follow-up-2, MTL-1800-follow-up-2) Update "metal-provision" from "git@github.com:Cray-HPE/metal-provision.git@MTL-1800-fix-reverted-files"
- f62a75f4f Squashed 'vendor/github.com/Cray-HPE/metal-provision/' changes from 1927d3ce0..a52098c75
- 450938e77 (tag: 0.3.10-1, origin/MTL-1800-daemons, MTL-1800-daemons) Update "metal-provision" from "git@github.com:Cray-HPE/metal-provision.git@main"
- 4c90c2ad2 Add fail flag to curl