### PR TITLE
MTL-1761 Use new dracut-lib.sh

### DIFF
--- a/vendor/github.com/Cray-HPE/metal-provision/.github/PULL_REQUEST_TEMPLATE.md
+++ b/vendor/github.com/Cray-HPE/metal-provision/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,14 @@
-#### Summary and Scope
+### Summary and Scope
+
 <!--- Pick one below and delete the rest -->
+<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->
 
-- Fixes #
-- Requires #
-- Relates to #
+- Fixes:
+- Requires:
+- Relates to:
 
-##### Issue Type
+#### Issue Type
+
 <!--- Delete un-needed bullets -->
 
 - Bugfix Pull Request
@@ -14,15 +17,27 @@
 
 <!--- words; describe what this change is and what it is for. -->
 
-#### Prerequisites
+### Prerequisites
+
+<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
+<!--- unchecked checkbox: [ ] -->
+<!--- checked checkbox: [x] -->
+<!--- invalid checkbox: [] -->
 
 - [ ] I have included documentation in my PR (or it is not required)
-- [ ] I tested this on internal system (x) (if yes, please include results or a description of the test)
+- [ ] I tested this on internal system (if yes, please include results or a description of the test)
+- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
  
-#### Idempotency
+### Idempotency
  
 <!--- describe testing done to verify code changes behave in an idempotent manner -->
  
-#### Risks and Mitigations
+### Risks and Mitigations
  
 <!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
+<!--- Example:
+
+This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
+is resolved and the overall risk of fatal failures is reduced.
+
+-->

--- a/vendor/github.com/Cray-HPE/metal-provision/.github/workflows/shellcheck.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/.github/workflows/shellcheck.yml
@@ -38,3 +38,5 @@ jobs:
     
     - name: run shellcheck
       uses: ludeeus/action-shellcheck@1.1.0
+      with:
+        severity: warning

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/scripts/common/cleanup-kis-artifacts.sh
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/scripts/common/cleanup-kis-artifacts.sh
@@ -1,7 +1,27 @@
 #!/bin/bash
-
+#
+# MIT License
+#
+# (C) Copyright 2021-2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 set -e
 
-umount /mnt/squashfs
-rm -rf /mnt/squashfs
 rm -rf /squashfs

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/scripts/common/create-ims-initrd.sh
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/scripts/common/create-ims-initrd.sh
@@ -23,29 +23,28 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-# This script does not use bind mounts and thus executes correctly in a container
+# This script does not use bind mounts and thus executes correctly in a container.
 set -e
 set -x
 
-echo "Generating initrd..."
 
-version_full=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-default)
-version_base=${version_full%%-*}
-version_suse=${version_full##*-}
-version_suse=${version_suse%.*.*}
-version="$version_base-$version_suse-default"
+# Source common dracut parameters.
+. "$(dirname $0)/dracut-lib.sh"
+
+echo "Generating initrd..."
 
 dracut \
 --force \
---omit 'cifs ntfs-3g btrfs nfs fcoe iscsi modsign fcoe-uefi nbd dmraid multipath dmsquash-live-ntfs' \
---omit-drivers 'ecb md5 hmac' \
---add 'mdraid' \
---force-add 'dmsquash-live livenet mdraid' \
---kver ${version} \
+--omit "$(printf '%s' "${OMIT[*]}")" \
+--omit-drivers "$(printf '%s' "${OMIT_DRIVERS[*]}")" \
+--add "$(printf '%s' "${ADD[*]}")" \
+--force-add "$(printf '%s' "${FORCE_ADD[*]}")" \
+--install "$(printf '%s' "${INSTALL[*]}")" \
+--kver "${KVER}" \
 --no-hostonly \
 --no-hostonly-cmdline \
 --printsize \
 --xz \
-/boot/initrd-${version}
+"/boot/initrd-${KVER}"
 
 exit 0

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/scripts/common/dracut-lib.sh
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/scripts/common/dracut-lib.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 #
 # MIT License
 #
@@ -24,36 +23,16 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 
-set -e
+# Dracut Arguments
+export OMIT=( "btrfs" "cifs" "dmraid" "dmsquash-live-ntfs" "fcoe" "fcoe-uefi" "iscsi" "modsign" "multipath" "nbd" "nfs" "ntfs-3g" )
+export OMIT_DRIVERS=( "ecb" "hmac" "md5" )
+export ADD=( "mdraid" )
+export FORCE_ADD=( "dmsquash-live" "livenet" "mdraid" )
+export INSTALL=( "less" "rmdir" "sgdisk" "vgremove" "wipefs" )
 
-CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd )"
-echo "$CURRENT_DIR"
-
-function list-custom-repos-file() {
-  cat <<EOF
-${CURRENT_DIR}/${CUSTOM_REPOS_FILE}
-EOF
-}
-
-function remove-comments-and-empty-lines() {
-  sed -e 's/#.*$//' -e '/^[[:space:]]*$/d'
-}
-
-function zypper-add-repos() {
-  remove-comments-and-empty-lines \
-  | awk '{ NF-=1; print }' \
-  | while read url name flags; do
-    local alias="buildonly-${name}"
-    echo "Adding repo ${alias} at ${url}"
-    zypper -n addrepo $flags "${url}" "${alias}"
-    zypper -n --gpg-auto-import-keys refresh "${alias}"
-  done
-}
-
-if [ -z "$CUSTOM_REPOS_FILE" ]; then
-  echo "Not using a custom repo."
-  source /srv/cray/csm-rpms/scripts/rpm-functions.sh
-else
-  echo "Using custom repos file: '${CUSTOM_REPOS_FILE}'."
-  list-custom-repos-file | xargs -r cat | zypper-add-repos
-fi
+# Kernel Version
+version_full=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}.%{ARCH}\n" kernel-default)
+version_base=${version_full%%-*}
+version_suse=${version_full##*-}
+version_suse=${version_suse%.*.*}
+export KVER="${version_base}-${version_suse}-default"


### PR DESCRIPTION
### Summary and Scope

**This requires https://github.com/Cray-HPE/metal-provision/pull/10 to merge first, if more changes are made to that PR then this PR requires a rebuild/redo.**

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1761

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
We often repeat static inputs to dracut in our scripts, this adds a library and updates the following scripts to use the library:
- `create-ims-initrd.sh`
- `create-kdump-artifacts.sh`
- `create-kexec-initrd.sh`
- `create-kis-artifacts.sh`

Each script was tested on metal to verify that the modifications worked.

Lastly this also resolves an old problem where a mount point would exist after running `create-kis-artifacts.sh`:

```bash
redbull-ncn-m001-pit: # mount | grep 'squashfs-root'
/dev/sdd4 on /var/www/ephemeral/data/k8s/0.3.12/squashfs-root/mnt/squashfs type ext4 (rw,noatime)
redbull-ncn-m001-pit: #umount /var/www/ephemeral/data/k8s/0.3.12/squashfs-root/mnt/squashfs
```
That was fixed by adding a `trap` to `create-kis-artifacts.sh` that `umounts` the `/mnt/squashfs` dir from within the chroot before exiting.

Additionally, @dmjacobsen 's recommendation to use `unshare` vs. `chroot` in `create-kis-artifacts.sh` is implemented.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
This provides less risk because maintainers can refer to lengthy dracut params via a library.