### PR TITLE
MTL-1820 Sync aliases from cray-pre-install-toolkit

### DIFF
--- a/boxes/pit-common/pit-common.pkr.hcl
+++ b/boxes/pit-common/pit-common.pkr.hcl
@@ -89,12 +89,6 @@ build {
     destination = "/tmp/files/"
   }
 
-  # Probably want to keep this
-  provisioner "file" {
-    source = "custom"
-    destination = "/tmp/files/"
-  }
-
   // Setup each context (e.g. common, google, and metal)
   provisioner "shell" {
     environment_vars = [
@@ -115,17 +109,19 @@ build {
 #  }
 
   provisioner "shell" {
-    inline = [
-      "bash -c 'rpm --import https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc'"]
-  }
-
-  provisioner "shell" {
     environment_vars = [
       "CUSTOM_REPOS_FILE=${var.custom_repos_file}",
       "ARTIFACTORY_USER=${var.artifactory_user}",
       "ARTIFACTORY_TOKEN=${var.artifactory_token}"
     ]
-    inline = ["bash -c /srv/cray/custom/repos.sh"]
+    inline = [
+      "bash -c '. /srv/cray/csm-rpms/scripts/rpm-functions.sh; setup-package-repos'"]
+    valid_exit_codes = [0, 123]
+  }
+
+  provisioner "shell" {
+    inline = [
+      "bash -c 'rpm --import https://arti.dev.cray.com/artifactory/dst-misc-stable-local/SigningKeys/HPE-SHASTA-RPM-PROD.asc'"]
   }
 
   provisioner "shell" {

--- a/boxes/pit-common/provisioners/common/install.sh
+++ b/boxes/pit-common/provisioners/common/install.sh
@@ -64,8 +64,8 @@ cat << EOF >> /root/.bashrc
 alias ip='ip -c'
 alias ll='ls -l --color'
 alias lid='for file in \$(ls -1d /sys/bus/pci/drivers/*/0000\:*/net/*); do printf "% -6s %s\n" "\$(basename \$file)" \$(grep PCI_ID "\$(dirname \$(dirname \$file))/uevent" | cut -f 2 -d '='); done'
-alias wipeoff="sed -i 's/metal.no-wipe=0/metal.no-wipe=1/g' /var/www/boot/script.ipxe && set-sqfs-links.sh"
-alias wipeon="sed -i 's/metal.no-wipe=1/metal.no-wipe=0/g' /var/www/boot/script.ipxe && set-sqfs-links.sh"
+alias wipeoff="for script in /var/www/ncn-*/script.ipxe; do sed -i 's/metal.no-wipe=0/metal.no-wipe=1/g' \\\$script; done; wipestat"
+alias wipeon="for script in /var/www/ncn-*/script.ipxe; do sed -i 's/metal.no-wipe=1/metal.no-wipe=0/g' \\\$script; done; wipestat"
 alias wipestat='grep -o metal.no-wipe=[01] /var/www/ncn-*/script.ipxe'
 source <(kubectl completion bash) 2>/dev/null
 EOF

--- a/boxes/pit-common/provisioners/common/setup.sh
+++ b/boxes/pit-common/provisioners/common/setup.sh
@@ -32,7 +32,6 @@ mkdir -pv /srv/cray
 cp -prv /tmp/files/* /srv/cray/ && rm -rf /tmp/files
 find /srv/cray/scripts -type f -name *.sh -exec chmod +x {} \+
 
-
 #======================================
 # Copy resources
 #--------------------------------------


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1820

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
This was fixed in cray-pre-install-toolkit, this PR is ensuring that pit-common doesn't drift from what's in cray-pre-install-toolkit.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
