### PR TITLE
Fix vendor ref

### DIFF
--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/scripts/common/chrony/csm_ntp.py
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common-setup/files/srv/cray/scripts/common/chrony/csm_ntp.py
@@ -97,7 +97,7 @@ def get_bss_data(token, xname):
         if response.ok:
             # BSS response has a different structure than the local cache
             try:
-                return bss_data.json()[0]["cloud-init"]["user-data"]
+                return response.json()[0]["cloud-init"]["user-data"]
             except KeyError:
                 print("Please validate your BSS data.")
                 sys.exit(2)


### PR DESCRIPTION
### Summary and Scope

We were pointing to metal-provision / MTL-1761. Now points to metal-provision / main.

- Fixes:
Pointing to incorrect vendor ref.
`git vendor update metal-provision main` vs. `git vendor update metal-provision MTL-1761`

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
yes
