### PR TITLE
MTL-1748 Revert and Benign Include of CASMTRIAGE-3640

### DIFF
--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
@@ -10,7 +10,7 @@ loftsman=1.2.0-1
 manifestgen=1.3.6-1
 
 # CSM METAL-team Packages
-cray-site-init=1.20.0-1
+cray-site-init=1.20.1-1
 ilorest=3.5.1-1
 metal-basecamp=1.2.0-1
 metal-ipxe=2.2.7-1

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-kubernetes/metal.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-kubernetes/metal.packages
@@ -1,4 +1,4 @@
 dracut-metal-dmk8s=2.0.0-1
-dracut-metal-luksetcd=2.0.0-1
+dracut-metal-luksetcd=2.0.2-1
 haproxy=2.0.14-bp152.1.1
 keepalived=2.0.19-bp152.1.9


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1748 & CASMTRIAGE-3640

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Pulls in two changes:
- CASMTRIAGE-3640 (not used) for pit-common (see: https://github.com/Cray-HPE/cray-site-init/pull/201)
- MTL-1748 REVERT for fixing LUKS disks on NVME (see: https://github.com/Cray-HPE/dracut-metal-luksetcd/pull/36)

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I (@jpdavis-prof did this on behalf of me) tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
