### PR TITLE
MTL-1837 Try/catch publishes to base & pit-common

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -11,12 +11,17 @@
     NOTE: Until the PIT Common layer produces an ISO it is skipped, it takes time to build and isn't used at all in its current form.
  */
 
+// Release toggles; define stable, and when to rebuild from a stable branch.
 def promotionToken = ~"(master|main|develop|lts\\/.*)"
 def buildAndPublish = env.TAG_NAME == null && !(env.BRANCH_NAME ==~ promotionToken) ? true : false
-def buildPIT = false // TODO: Toggle to True once we have ISOs working (MTL-1476)
+def sourceBuildVersion = '[RELEASE]' // Pulls the latest release
+
+// Rebuild toggles; never build base unless explicitly required, always rebuild common.
 def rebuildBaseImage = false
 def rebuildCommonImage = env.TAG_NAME == null ? true : false
-def sourceBuildVersion = '[RELEASE]' // Pulls the latest release
+
+// Temporary toggles; useful for certain contexts.
+def buildPIT = false // TODO: Toggle to True once we have ISOs working (MTL-1476)
 def disableGoogle = false   // FIXME: Once SLES15SP4 is supported in Google, set this to false.
 
 // Global vars to be set within stages.
@@ -44,30 +49,24 @@ pipeline {
     }
 
     environment {
-        NAME = "cray-node-image-build"
-        DESCRIPTION = "Cray Management System Node Image Builder"
-        VERSION = setImageVersion(commitHashShort: GIT_COMMIT[0..6])
         ARTIFACTS_DIRECTORY_BASE = "output-sles15-base"
-        ARTIFACTS_DIRECTORY_COMMON = "output-ncn-common"
         ARTIFACTS_DIRECTORY_CEPH = "output-ncn-node-images/storage-ceph"
+        ARTIFACTS_DIRECTORY_COMMON = "output-ncn-common"
         ARTIFACTS_DIRECTORY_K8S = "output-ncn-node-images/kubernetes"
         ARTIFACTS_DIRECTORY_PIT = "output-pit-common"
         ISO = "SLE-15-SP3-Online-x86_64-GM-Media1.iso"
         ISO_URL = "https://artifactory.algol60.net/artifactory/os-images"
-        STABLE_BASE = "https://artifactory.algol60.net/artifactory/csm-images/stable"
         NPROC = sh(returnStdout: true, script: "nproc").trim()
         NRAM = '4096'
-        BUILD_DATE = sh(returnStdout: true, script: "date -u '+%Y%m%d%H%M%S'").trim()
-        GIT_TAG = sh(returnStdout: true, script: "git fetch origin --tags && git describe --tags --abbrev=0").trim()
-        GIT_HASH = "${GIT_COMMIT[0..6]}"
-        PKR_VAR_pit_slug = "${GIT_TAG}/${BUILD_DATE}/g${GIT_HASH}"
+        STABLE_BASE = "https://artifactory.algol60.net/artifactory/csm-images/stable"
+        VERSION = setImageVersion(commitHashShort: GIT_COMMIT[0..6])
     }
 
     parameters {
-        booleanParam(name: 'buildAndPublish', defaultValue: buildAndPublish, description: '(leave unchecked for; git-tags, main, and develop) Whether or not to actually rebuild and publish for a stable merge build job.')
-        booleanParam(name: 'buildPIT', defaultValue: buildPIT, description: 'Build the PIT Image (disabled until MTL-1476).')
-        booleanParam(name: 'rebuildBaseImage', defaultValue: rebuildBaseImage, description: 'Whether or not to build the base image; unchecked will pull latest STABLE base. FOR GIT TAGS if a base image was built and needs to be promoted then this MUST be checked (This overrides rebuildCommonImage; if this is true, rebuildCommonImage is bypassed.)')
-        booleanParam(name: 'rebuildCommonImage', defaultValue: rebuildCommonImage, description: '(leave unchecked for; git-tags, main, and develop) Whether or not to build the common image; unchecked will pull latest STABLE ncn-common.')
+        booleanParam(name: 'buildAndPublish', defaultValue: buildAndPublish, description: 'Whether or not main, develop, lts/*, or git-tags should rebuild their current HASH. When unchecked these branches and git-tags will only verify their hash has been promoted.')
+        booleanParam(name: 'buildPIT', defaultValue: buildPIT, description: 'Build the PIT Image (experimental, after MTL-1476 merges this should always build and the parameter will go away.')
+        booleanParam(name: 'rebuildBaseImage', defaultValue: rebuildBaseImage, description: 'If disabled, the common layer will build on the latest stable base image in Artifactory. If enabled, the base image will be rebuilt fresh. This layer DOES NOT need to build for publishing to succeed after a git-tag.')
+        booleanParam(name: 'rebuildCommonImage', defaultValue: rebuildCommonImage, description: 'If disabled, the child images (Kubernetes & Storage-CEPH) will built atop the latest stable common image in Artifactory. If enabled, the common image will be rebuilt fresh. This layer needs to build for publishing to succeed after a git-tag.')
         string(name: 'googleSourceImageProjectId', defaultValue: "artifactory-202004", description: 'The source Project ID for pulling Google images.')
     }
 
@@ -164,6 +163,23 @@ pipeline {
             }
         }
         stage('Common Layers') {
+            environment {
+                /*
+                    The following variables are for the pit-common layer:
+                    - BUILD_DATE
+                    - GIT_HASH
+                    - GIT_TAG
+                    - PKG_VAR_pit_slug
+
+                    These have to be the same for every pit-common build between Google and Metal. If these moved into the Google and Metal stages
+                    then they would differ by a few seconds. The only way to make them the same in the Jenkinsfile's current state is to define them
+                    for all four common builds (ncn-common:google, ncn-common:metal, pit-common:google, pit-common:metal).
+                */
+                BUILD_DATE = sh(returnStdout: true, script: "date -u '+%Y%m%d%H%M%S'").trim()
+                GIT_HASH = "${GIT_COMMIT[0..6]}"
+                GIT_TAG = sh(returnStdout: true, script: "git fetch origin --tags && git describe --tags --abbrev=0").trim()
+                PKR_VAR_pit_slug = "${GIT_TAG}/${BUILD_DATE}/g${GIT_HASH}"
+            }
             when {
                 expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
             }
@@ -544,18 +560,27 @@ pipeline {
                 ]) {
                     script {
 
-                        if (params.rebuildBaseImage) {
-
+                        /*
+                            Use a try/catch block to prevent sles15-base and pit-common from requiring an administrator to manually build a git-tag. This
+                            manual process is tedious, and prone to mistakes, this way the Jenkins pipeline will always try to publish these layers.
+                        */
+                        try {
                             publishCsmImages.release('sles15-base', GIT_COMMIT[0..6], env.TAG_NAME, GOOGLE_CLOUD_SA_KEY)
-
+                        } catch (err) {
+                            echo err.getMessage()
+                            echo 'The build attempted to publish a sles15-base image but none was found, this may or may not be expected.'
                         }
-
-                        if (params.buildPIT) {
-
+                        try {
                             publishCsmImages.release('pit-common', GIT_COMMIT[0..6], env.TAG_NAME, GOOGLE_CLOUD_SA_KEY)
-
+                        } catch (err) {
+                            echo err.getMessage()
+                            echo 'The build attempted to publish a pit-common image but none was found, this may or may not be expected.'
                         }
 
+                        /*
+                            These three layers are always built and required for publishing.
+                            In the near future we'll cease always requiring the common layer to build.
+                        */
                         publishCsmImages.release('ncn-common', GIT_COMMIT[0..6], env.TAG_NAME, GOOGLE_CLOUD_SA_KEY)
                         publishCsmImages.release('storage-ceph', GIT_COMMIT[0..6], env.TAG_NAME, GOOGLE_CLOUD_SA_KEY)
                         publishCsmImages.release('kubernetes', GIT_COMMIT[0..6], env.TAG_NAME, GOOGLE_CLOUD_SA_KEY)


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Docs Pull Request

<!--- words; describe what this change is and what it is for. -->
Remove manual steps admins must complete for publishing base and pit-common.

Reword parameter descriptions.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
This'll remove risk of an administrator forgetting to cancel or not canceling a git-tag build in time before it publishes anything _in_ the case they want to publish a base image.

The current problem is that if a base or pit-common image must be published, an Administrator must race to the tag build and be ready to cancel it after it has pulled the Jenkinsfile and enabled "Build with Parameters." Then the administrator can toggle publishing base or pit-common. If the admin. is too late, they have to cleanup builds already published into GCP (since GCP doesn't allow overwrite). If an admin. is too early, the build won't have scanned the Jenkinsfile and won't have "Build with Parameters."

This change ensures that base and pit-common are tried, and if they do not exist then they do not fail the build.