### PR TITLE
Re-introduce google/setup.sh

### DIFF
--- a/boxes/ncn-common/provisioners/google/setup.sh
+++ b/boxes/ncn-common/provisioners/google/setup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+# Establish that this is a google system
+touch /etc/google_system
+
+echo "activate public cloud module"
+product=$(sudo SUSEConnect --list-extensions | grep -o "sle-module-public-cloud.*")
+[[ -n "$product" ]] && sudo SUSEConnect -p "$product"
+
+echo "install guest environment packages"
+zypper refresh
+zypper install -y google-guest-{agent,configs,oslogin} google-osconfig-agent
+systemctl enable /usr/lib/systemd/system/google-*
+
+echo "Modifying DNS to use Cray DNS servers..."
+cp /etc/sysconfig/network/config /etc/sysconfig/network/config.backup
+sed -i 's|^NETCONFIG_DNS_STATIC_SERVERS=.*$|NETCONFIG_DNS_STATIC_SERVERS="172.31.84.40 172.30.84.40"|g' /etc/sysconfig/network/config
+systemctl restart network
+
+echo "Stubbing out network interface configuration files"
+for i in {0..10}; do
+  cat << 'EOF' > /etc/sysconfig/network/ifcfg-eth${i}
+BOOTPROTO='dhcp'
+STARTMODE='auto'
+EOF
+done
+cp /srv/cray/sysctl/google/* /etc/sysctl.d/
+
+# TODO: something keeps removing authorized_keys for root, at the very least in Virtual Shasta, we need it to stick around
+echo "Scheduling job to ensure /root/.ssh/authorized_keys file is our /root/.ssh/id_rsa.pub only every 1 minute"
+echo "*/1 * * * * cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys >> /var/log/cray/cron.log 2>&1" > /etc/cron.d/cray-maintain-root-authorized-keys


### PR DESCRIPTION
### Summary and Scope

At one point in git history, this file contained an SSH key.
When the repo was scrubbed to remove that from history, it ended
up removing the file entirely. This commit adds it back, as it
was at lts/csm-1.2 HEAD prior to the repo scrub.


<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

-->
