### PR TITLE
Pin python client to same version of k8s

### DIFF
--- a/boxes/ncn-node-images/kubernetes/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/kubernetes/provisioners/common/install.sh
@@ -93,7 +93,9 @@ modprobe br_netfilter
 
 echo "Installing kubernetes python client"
 pip3 install --ignore-installed PyYAML
-pip3 install kubernetes
+KUBELET_VER=$(rpm -qa | grep kubelet |  awk -F '-' '{print $2}')
+K8S_MINOR_VERSION=$(echo $KUBELET_VER | awk -F '.' '{print $2}')
+pip3 install "kubernetes==${K8S_MINOR_VERSION}.*" --upgrade
 
 echo "Setting TasksMax to infinity via 10-kubelet.conf file"
 mkdir -p /etc/systemd/system/kubelet.service.d


### PR DESCRIPTION
### Summary and Scope

Suse's rpm is stale -- use the version of kubernetes for the install to pin python3-kubernetes package.

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMPET-5814

#### Issue Type

- Bugfix Pull Request

```
ncn-m001:~ # pip3 freeze | grep kuber
kubernetes==21.7.0
```

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on a craystack system (if yes, please include results or a description of the test)
 
### Idempotency
 
Yup

### Risks and Mitigations
 
Low
