### PR TITLE
MTL-1840 install kata containers, bundled with qemu-system-x86_64

### DIFF
--- a/boxes/ncn-node-images/kubernetes/files/resources/common/vars.sh
+++ b/boxes/ncn-node-images/kubernetes/files/resources/common/vars.sh
@@ -37,6 +37,7 @@ export HELM_V3_VERSION="3.2.4"
 export VELERO_VERSION="v1.5.2"
 export ETCD_VERSION="v3.5.0"
 export PAUSE_VERSION="3.4.1"
+export KATA_VERSION="2.4.3"
 #
 # https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md
 #

--- a/boxes/ncn-node-images/kubernetes/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/kubernetes/provisioners/common/install.sh
@@ -38,6 +38,9 @@ mkdir -p /opt/cray/tbd
 mkdir -p /var/run/sds
 echo "${KUBERNETES_PULL_VERSION}" > /etc/cray/kubernetes/version
 
+echo "Installing kata containers"
+wget -q -c https://github.com/kata-containers/kata-containers/releases/download/${KATA_VERSION}/kata-static-${KATA_VERSION}-x86_64.tar.xz -O - | tar -xJ -C /
+
 echo "Installing etcd binaries"
 mkdir -p /tmp/etcd
 wget -q -O /tmp/etcd/etcd-${ETCD_VERSION}-linux-amd64.tar.gz https://github.com/etcd-io/etcd/releases/download/${ETCD_VERSION}/etcd-${ETCD_VERSION}-linux-amd64.tar.gz


### PR DESCRIPTION
### Summary and Scope

https://jira-pro.its.hpecorp.net:8443/browse/MTL-1840

- Fixes: MTL-1840

#### Issue Type

- RFE Pull Request
Installs kata containers bundled with qemu-system-x86_64. This does not include dependencies for running ARM environments.

### Prerequisites

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
Idempotency will come when porting to ansible. Currently there isn't any ansible framework in place for worker and storage nodes. 
 
### Risks and Mitigations
 
The Kata environment is self-contained and doesn't present any risks to the existing environment. 