### PR TITLE
CASMINST-5037 Fix extension for kubeadm file in token refresh script

### DIFF
--- a/boxes/ncn-common/provisioners/common/install.sh
+++ b/boxes/ncn-common/provisioners/common/install.sh
@@ -30,18 +30,20 @@ set -ex
 # Clean up old kernels, if any. We should only ship with a single kernel.
 # Lock the kernel to prevent inadvertent updates.
 function kernel {
-    local sles15_kernel_version
-    sles15_kernel_version=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}\n" kernel-default)
+    local current_kernel
+
+    # Grab this from csm-rpms, the running kernel may not match the kernel we installed and want until the image is rebooted.
+    # This ensures we lock to what we want installed.
+    current_kernel="$(grep kernel-default /srv/cray/csm-rpms/packages/node-image-non-compute-common/base.packages | awk -F '=' '{print $NF}')"
 
     echo "Purging old kernels ... "
-    sed -i 's/^multiversion.kernels =.*/multiversion.kernels = '"${SLES15_KERNEL_VERSION}"'/g' /etc/zypp/zypp.conf
+    sed -i 's/^multiversion.kernels =.*/multiversion.kernels = '"${current_kernel}"'/g' /etc/zypp/zypp.conf
     zypper --non-interactive purge-kernels --details
 
-    echo "Locking the kernel to $SLES15_KERNEL_VERSION"
-    zypper addlock kernel-default
-
-    echo 'Listing locks and kernel RPM(s)'
-    zypper ll
+    echo "Locking the kernel to ${current_kernel}"
+    zypper addlock kernel-default && zypper locks
+        
+    echo "Listing currently installed kernel-default RPM:"
     rpm -qa | grep kernel-default
 }
 kernel

--- a/boxes/ncn-node-images/kubernetes/files/scripts/common/kubernetes-cloudinit.sh
+++ b/boxes/ncn-node-images/kubernetes/files/scripts/common/kubernetes-cloudinit.sh
@@ -150,7 +150,7 @@ function post-join() {
 export KUBECONFIG=/etc/kubernetes/admin.conf
 
 if [[ "$1" != "skip-upload-certs" ]]; then
-  kubeadm init phase upload-certs --upload-certs --config /etc/cray/kubernetes/kubeadm.cfg
+  kubeadm init phase upload-certs --upload-certs --config /etc/cray/kubernetes/kubeadm.yaml
 fi
 kubeadm token create --print-join-command > /etc/cray/kubernetes/join-command 2>/dev/null
 echo "$(cat /etc/cray/kubernetes/join-command) --control-plane --certificate-key $(cat /etc/cray/kubernetes/certificate-key)" \

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
@@ -15,8 +15,14 @@ loftsman=1.2.0-1
 manifestgen=1.3.7-1
 
 # CSM METAL-team Packages
-cray-site-init=1.21.0-1
+cray-site-init=1.22.0-1
 ilorest=3.5.1-1
+kernel-default=5.3.18-150300.59.76.1
+kernel-firmware=20210208-150300.4.10.1
+# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
+kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
+kernel-source=5.3.18-150300.59.76.1
+kernel-syms=5.3.18-150300.59.76.1
 metal-basecamp=1.2.0-1
 metal-ipxe=2.2.8-1
 metal-net-scripts=0.0.2-1

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/metal.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/metal.packages
@@ -8,12 +8,6 @@ grub2-branding-SLE=15-33.3.1
 grub2-i386-pc=2.04-150300.22.20.2
 grub2-x86_64-efi=2.04-150300.22.20.2
 grub2=2.04-150300.22.20.2
-kernel-default=5.3.18-150300.59.76.1
-kernel-firmware=20210208-150300.4.10.1
-# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
-kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
-kernel-source=5.3.18-150300.59.76.1
-kernel-syms=5.3.18-150300.59.76.1
 ledmon=0.94-1.59
 # DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
 mft=4.20.0-34

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/base.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/base.packages
@@ -131,6 +131,14 @@ craycli=0.57.0-1
 csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.36-1
 
+# CSM Metal
+kernel-default=5.3.18-150300.59.76.1
+kernel-firmware=20210208-150300.4.10.1
+# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
+kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
+kernel-source=5.3.18-150300.59.76.1
+kernel-syms=5.3.18-150300.59.76.1
+
 # CSM Testing Utils
 goss-servers=1.14.31-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/metal.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/metal.packages
@@ -9,12 +9,6 @@ grub2-branding-SLE=15-33.3.1
 grub2-i386-pc=2.04-150300.22.20.2
 grub2-x86_64-efi=2.04-150300.22.20.2
 grub2=2.04-150300.22.20.2
-kernel-default=5.3.18-150300.59.76.1
-kernel-firmware=20210208-150300.4.10.1
-# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
-kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
-kernel-source=5.3.18-150300.59.76.1
-kernel-syms=5.3.18-150300.59.76.1
 ledmon=0.94-1.59
 mdadm=4.1-150300.24.15.1
 # DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"


### PR DESCRIPTION
### Summary and Scope

Fix extension for renamed file

- Fixes: https://jira-pro.its.hpecorp.net:8443/browse/CASMINST-5037

#### Issue Type

- Bugfix Pull Request

Adapt to new kubeadm.yaml file name

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on a craystack system (if yes, please include results or a description of the test)

```
ncn-m001:/srv/cray/scripts/kubernetes # ./token-certs-refresh.sh
[upload-certs] Storing the certificates in Secret "kubeadm-certs" in the "kube-system" Namespace
[upload-certs] Using certificate key:
878f4d424f294ac5c3698eadfb2a7dc3fe8e5c2da154bbd4390dd82378d3fc12
```

### Idempotency
 
N/A
 
### Risks and Mitigations
 
Low