### PR TITLE
MTL-1853 Lock to csm-rpms kernel

### DIFF
--- a/boxes/ncn-common/provisioners/common/install.sh
+++ b/boxes/ncn-common/provisioners/common/install.sh
@@ -30,18 +30,20 @@ set -ex
 # Clean up old kernels, if any. We should only ship with a single kernel.
 # Lock the kernel to prevent inadvertent updates.
 function kernel {
-    local sles15_kernel_version
-    sles15_kernel_version=$(rpm -q --queryformat "%{VERSION}-%{RELEASE}\n" kernel-default)
+    local current_kernel
+
+    # Grab this from csm-rpms, the running kernel may not match the kernel we installed and want until the image is rebooted.
+    # This ensures we lock to what we want installed.
+    current_kernel="$(grep kernel-default /srv/cray/csm-rpms/packages/node-image-non-compute-common/base.packages | awk -F '=' '{print $NF}')"
 
     echo "Purging old kernels ... "
-    sed -i 's/^multiversion.kernels =.*/multiversion.kernels = '"${SLES15_KERNEL_VERSION}"'/g' /etc/zypp/zypp.conf
+    sed -i 's/^multiversion.kernels =.*/multiversion.kernels = '"${current_kernel}"'/g' /etc/zypp/zypp.conf
     zypper --non-interactive purge-kernels --details
 
-    echo "Locking the kernel to $SLES15_KERNEL_VERSION"
-    zypper addlock kernel-default
-
-    echo 'Listing locks and kernel RPM(s)'
-    zypper ll
+    echo "Locking the kernel to ${current_kernel}"
+    zypper addlock kernel-default && zypper locks
+        
+    echo "Listing currently installed kernel-default RPM:"
     rpm -qa | grep kernel-default
 }
 kernel

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/base.packages
@@ -15,8 +15,14 @@ loftsman=1.2.0-1
 manifestgen=1.3.7-1
 
 # CSM METAL-team Packages
-cray-site-init=1.21.0-1
+cray-site-init=1.22.0-1
 ilorest=3.5.1-1
+kernel-default=5.3.18-150300.59.76.1
+kernel-firmware=20210208-150300.4.10.1
+# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
+kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
+kernel-source=5.3.18-150300.59.76.1
+kernel-syms=5.3.18-150300.59.76.1
 metal-basecamp=1.2.0-1
 metal-ipxe=2.2.8-1
 metal-net-scripts=0.0.2-1

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/metal.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/cray-pre-install-toolkit/metal.packages
@@ -8,12 +8,6 @@ grub2-branding-SLE=15-33.3.1
 grub2-i386-pc=2.04-150300.22.20.2
 grub2-x86_64-efi=2.04-150300.22.20.2
 grub2=2.04-150300.22.20.2
-kernel-default=5.3.18-150300.59.76.1
-kernel-firmware=20210208-150300.4.10.1
-# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
-kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
-kernel-source=5.3.18-150300.59.76.1
-kernel-syms=5.3.18-150300.59.76.1
 ledmon=0.94-1.59
 # DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"
 mft=4.20.0-34

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/base.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/base.packages
@@ -131,6 +131,14 @@ craycli=0.57.0-1
 csm-node-identity=1.0.18-1
 hpe-csm-scripts=0.0.36-1
 
+# CSM Metal
+kernel-default=5.3.18-150300.59.76.1
+kernel-firmware=20210208-150300.4.10.1
+# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
+kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
+kernel-source=5.3.18-150300.59.76.1
+kernel-syms=5.3.18-150300.59.76.1
+
 # CSM Testing Utils
 goss-servers=1.14.31-1
 hpe-csm-goss-package=0.3.13-20210615152800_aae8d77

--- a/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/metal.packages
+++ b/vendor/github.com/Cray-HPE/csm-rpms/packages/node-image-non-compute-common/metal.packages
@@ -9,12 +9,6 @@ grub2-branding-SLE=15-33.3.1
 grub2-i386-pc=2.04-150300.22.20.2
 grub2-x86_64-efi=2.04-150300.22.20.2
 grub2=2.04-150300.22.20.2
-kernel-default=5.3.18-150300.59.76.1
-kernel-firmware=20210208-150300.4.10.1
-# When we move to SP4 double-check this has a matching kernel, if not then kernel-mft-mlnx-kmp-default needs to be commented out.
-kernel-mft-mlnx-kmp-default=4.20.0_k5.3.18_57-1.sles15sp3
-kernel-source=5.3.18-150300.59.76.1
-kernel-syms=5.3.18-150300.59.76.1
 ledmon=0.94-1.59
 mdadm=4.1-150300.24.15.1
 # DO NOT INSTALL MFT FROM THE SPP REPO, NEVER APPEND "slesXspY"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1853

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
Ensures only the kernel listed in csm-rpms (`kernel-default`) is installed. Purges all other kernels.

This does mean that `kexec` needs to update this value in `/etc/zypper/zypp.conf` and also run `purge-kernels`. The `zypp.conf` update will allow a new kernel to install, and the `purge-kernels` keeps things tidy (and maybe is undesired).

Example output:

```bash
+ kernel
+ local current_kernel
++ grep kernel-default /srv/cray/csm-rpms/packages/node-image-non-compute-common/base.packages
++ awk -F = '{print $NF}'
+ current_kernel=5.3.18-150300.59.76.1
Purging old kernels ...
+ echo 'Purging old kernels ... '
+ sed -i 's/^multiversion.kernels =.*/multiversion.kernels = 5.3.18-150300.59.76.1/g' /etc/zypp/zypp.conf
+ zypper --non-interactive purge-kernels --details
Reading installed packages...

Preparing to purge obsolete kernels...
Configuration: 5.3.18-150300.59.76.1
Running kernel release: 5.3.18-150300.59.81-default
Running kernel arch: x86_64

Resolving package dependencies...

The following package is going to be REMOVED:
kernel-default
  5.3.18-150300.59.81.1
  x86_64
  SUSE LLC <https://www.suse.com/>

1 package to remove.
After the operation, 150.9 MiB will be freed.
Continue? [y/n/v/...? shows all options] (y): y
kernel-default-5.3.18-150300.59.76.1.x86_64
(1/1) Removing kernel-default-5.3.18-150300.59.81.1.x86_64 [.....done]
There are running programs which still use files and libraries deleted or updated by recent upgrades. They should be restarted to benefit from the latest updates. Run 'zypper ps -s' to list these programs.

Since the last system boot core libraries or services have been updated.
Reboot is suggested to ensure that your system benefits from these updates.
+ echo 'Locking the kernel to 5.3.18-150300.59.76.1'
Locking the kernel to 5.3.18-150300.59.76.1
+ zypper addlock kernel-default
Specified lock has been successfully added.
+ zypper locks

# | Name             | Type    | Repository | Comment
--+------------------+---------+------------+--------
1 | btrfsmaintenance | package | (any)      |
2 | kernel-default   | package | (any)      |
+ echo 'Listing currently installed kernel-default RPM:'
+ rpm -qa
+ grep kernel-default

Listing currently installed kernel-default RPM:
kernel-default-devel-5.3.18-150300.59.76.1.x86_64
kernel-default-5.3.18-150300.59.76.1.x86_64
```


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
