### PR TITLE
CASMINST-4521: Add kubeadm identity configuration

### DIFF
--- a/boxes/ncn-node-images/kubernetes/files/resources/common/encryption-configuration.yaml
+++ b/boxes/ncn-node-images/kubernetes/files/resources/common/encryption-configuration.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+      - secrets
+    providers:
+      - identity: {}

--- a/boxes/ncn-node-images/kubernetes/files/resources/common/kubeadm.cfg
+++ b/boxes/ncn-node-images/kubernetes/files/resources/common/kubeadm.cfg
@@ -38,6 +38,7 @@ apiServer:
     oidc-ca-file: "/etc/kubernetes/pki/oidc.pem"
     oidc-username-claim: "name"
     oidc-groups-claim: "groups"
+    encryption-provider-config: /etc/cray/kubernetes/encryption/current.yaml
 
 controllerManager:
   extraArgs: ${CONTROLLER_MANAGER_EXTRA_ARGS}

--- a/boxes/ncn-node-images/kubernetes/files/scripts/common/kubernetes-cloudinit.sh
+++ b/boxes/ncn-node-images/kubernetes/files/scripts/common/kubernetes-cloudinit.sh
@@ -37,6 +37,9 @@ export ETCD_INITIAL_CLUSTER_STRING=$(get-etcd-initial-cluster-members)
 export ETCDCTL_BACKUP_ENDPOINTS=$(get-etcdctl-backup-endpoints)
 initialized_file="/etc/cray/kubernetes/initialized"
 
+# Script constants to reduce copypasta
+K8S_PREFIX=/etc/cray/kubernetes
+
 #
 # Expand the root disk (vshasta only)
 #
@@ -91,6 +94,24 @@ function wait-for-remote-file() {
   done
 }
 
+# Only applicable to control plane nodes, sets up
+# /etc/cray/kubernetes/encryption as needed as the kubelet process now has a
+# switch that requires the files to be present when things are started.
+function setup-encryption() {
+  # Note encryption files/setup is in its own sub directory to ensure the
+  # daemonset doesn't need to possibly have access to any other data than it
+  # truly needs.
+  echo "Installing default encryption configuration setup"
+  k8s_encryptiondir="${K8S_PREFIX}/encryption"
+  install -dm755 "${k8s_encryptiondir}"
+  install -dm400 /srv/cray/resources/common/encryption-configuration.yaml "${k8s_encryptiondir}/default.yaml"
+
+  # This is a nop setup for now, the current encryption is default/identity
+  # encryption which doesn't differ with anything today. Just lets etcd writes
+  # to go through the encryption machinery.
+  ln -sf "${k8s_encryptiondir}/default.yaml" "${k8s_encryptiondir}/current.yaml"
+}
+
 function join() {
   local join_script_remote="$1"
   local join_script_local="/etc/cray/kubernetes/join.sh"
@@ -102,6 +123,8 @@ function join() {
   #
   if [[ "$(hostname)" =~ ^ncn-m ]]; then
     echo "$(cat ${join_script_local}) --apiserver-advertise-address=${K8S_NODE_IP}" > ${join_script_local}
+    # All other control-plane nodes need encryption setups as well.
+    setup-encryption
   fi
 
   chmod 0700 $join_script_local
@@ -403,6 +426,8 @@ if [[ "$(hostname)" == $FIRST_MASTER_HOSTNAME ]] || [[ "$(hostname)" =~ ^$FIRST_
   export CERTIFICATE_KEY=$(cat /etc/cray/kubernetes/certificate-key)
 
   configure-load-balancer-for-master
+
+  setup-encryption
 
   envsubst < /srv/cray/resources/common/kubeadm.cfg > /etc/cray/kubernetes/kubeadm.yaml
   echo "Initializing Kubernetes on the first control plane node, pod cidr $PODS_CIDR, service cidr $SERVICES_CIDR"


### PR DESCRIPTION
This setup just basically turns on the encryption configuration
machinery in a default identity way. This means nothing has actually
changed as we're not using any encryption but we want this in place for
further changes.

### Summary and Scope


- Relates to: CASMINST-5130

#### Issue Type

- RFE Pull Request

This change enables the encryption provider for kubernetes/kubeadm. This initial commit for cloud init only enables it as a passthrough or identity configuration. So essentially this is a no op, but the directory created is used by a new DaemonSet to read configuration data from the current.yaml symlink.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (I hacked in a bit of a test on mug to recreate what would happen at cloud init time without a full boot)
- [x] I tested this on a vshasta system Validated the image can boot and I get the /etc/cray/kubernetes/encryption setup specified
 
### Idempotency
 
Ran the added function setup-encryption multiple times. Its rather short so hard to not make idempotent.
 
### Risks and Mitigations
 
As its a control plane change always a chance this introduces issues I'm not aware of booting k8s on bare metal.

Fortunately working around this setup is trivial, you can simply comment out the kubeapi extraargs for it and re-run kubeadm init.  As nothing is changed, aka no real encryption used its ultimately just a switch to turn on/off.

-->
