### PR TITLE
Do not mark `main` as release

### DIFF
--- a/.github/pr-branch-labeler.yml
+++ b/.github/pr-branch-labeler.yml
@@ -1,3 +1,3 @@
 # Apply label "release" if base matches "main" or "lts/*"
 release:
-  base: ["lts/*", "main"]
+  base: ["lts/*"]

--- a/README.adoc
+++ b/README.adoc
@@ -7,31 +7,29 @@
 This repository contains the https://www.packer.io/[Packer] pipepline code for building CRAY High-Performance Computing as a Service (HPCaaS)
 images for any distributable medium.
 
-The listed software below will equip a local machine or buildserver to build for any medium (`.squashfs`, `.vbox`, `.qcow2`, `.iso`, and `vagrant`).
+The listed software below will equip a local machine or buildserver to build for any medium (`.squashfs`, `.vbox`, and `.qcow2`).
 
 === Necessary Software
 
-* media (`.iso` or `.qcow2`) (depending on the layer)
-* packer
+* `envsubst` (optional; for base layer builds)
 * qemu
-* envsubst
-* git-vendor (for csm-rpms)
-* virtualbox (optional)
-* vagrant (optional)
+* libvirt (optional; for vagrant)
+* packer
+* virtualbox (optional; for virtualbox builds)
 
 === Media
 
 Packer can intake any ISO, the sections below detail utilized base ISOs in CRAY HPCaaS.
 
-For any ISO, copy it into the `iso` directory.
+For any ISO, copy it into the `iso/` directory.
 
 ==== SuSE Linux Enterprise
 
 Files that have been tested and verified to work:
 
- - `SLE-15-SP2-Full-x86_64-GM-Media1.iso`
- - `SLE-15-SP3-Full-x86_64-GM-Media1.iso`
- - `SLE-15-SP3-Online-x86_64-GM-Media1.iso`
+* `SLE-15-SP2-Full-x86_64-GM-Media1.iso`
+* `SLE-15-SP3-Full-x86_64-GM-Media1.iso`
+* `SLE-15-SP3-Online-x86_64-GM-Media1.iso`
 
 === Repositories
 
@@ -41,35 +39,34 @@ If you are using the default internal servers then you only need to pass `artifa
 
 - `-var 'artifactory_user=user' -var 'artifactory_token=token'`
 
-If you are building locally and want to provide your own repositories then the `custom_repos_file` variable must be passed with the packer command. The `custom_repos_file` variable is a filename that is placed into the `custom` folder of the project. The file must follow the same format as repos included in `csm-rpms` with the following fields: `url name flags`
-
-- `-var 'custom_repos_file=custom.repos'`
-
-And example entry for a custom repo:
-
-`https://myserver.net/sles-mirror/Products/SLE-Module-Basesystem/15-SP3/x86_64/product     SUSE-SLE-Module-Basesystem-15-SP3-x86_64-Pool     -g -p 99  suse/SLE-Module-Basesystem/15-SP3/x86_64/product`
-
 Furthermore, there may be additional repos used that are defined in `csm-rpms` which is checked out in the Quick Start section. You may be required to replace some or all of these files in `csm-rpms/repos/*.repos` to work with your environment.
 
-==== Working with CSM-RPMS
+==== Working with Git Vendor
 
-  If you need to adjust the version of `csm-rpms` in your repo, or make changes to the `csm-rpms` code base, you will
-  need to install git-vendor, which uses git submodules for managing dependencies.
+If you need to adjust the version of `csm-rpms` in your repo, or make changes to the `csm-rpms` code base, you will
+need to install git-vendor, which uses git submodules for managing dependencies.
 
   * `git vendor list` will show you the managed repos
   * `git vendor update csm-rpms release/1.2` will checkout the `release/1.2` branch of `csm-rpms`
   * All code for `csm-rpms` is stored in the `vendor` directory
 
-=== Build Steps
+Both `csm-rpms` and `metal-provision` are vendored.
 
-* There are two Providers that can be built; VirtualBox and QEMU
-* VirtualBox is best for local development.
-* QEMU is best for pipeline and portability on linux machines.
-* Both outputs are capable of creating the kernel, initrd, and squashfs required to boot nodes.
+== Build Steps
 
-==== Setup
+=== Setup
 
-* Install packer from a reputable endpoint, like *https://www.packer.io/downloads.html[this one]*.
+
+
+* Install packer
++
+[source,bash]
+----
+# macos
+brew install packer
+----
+* Install qemu
+* Optionally install Vagrant and libvirt for local builds of Vagrant boxes
 
 If you are building QEMU images in MacOS, you will need to adjust specific QEMU options:
 
@@ -78,124 +75,212 @@ If you are building QEMU images in MacOS, you will need to adjust specific QEMU 
 * `-var 'qemu_display=cocoa' -var 'qemu_accelerator=hvf'`
 
 
-==== Prerequisites
+[#_prerequisites]
+=== Prerequisites
 
-* Setup environment variables by copying `scripts/environment.template` to `scripts/environment` and modifying the values for your environment.
-* Ensure that `SLE-15-SP3-Full-x86_64-GM-Media1.iso` is in the `iso/` folder
-* Execute `source scripts/environment`
-* Execute `./scripts/setup.sh`
-* Render the autoinst template
+* Define variables needed for the NCN build.
++
+[source,bash]
+----
+export SLES15_INITIAL_ROOT_PASSWORD=
+----
++
+[source,bash]
+----
+# NOTE: This is only necessary for building the base layer.
+export SLES15_REGISTRATION_CODE=
+----
++
+[source,bash]
+----
+export ARTIFACTORY_USER=
+----
++
+[source,bash]
+----
+export ARTIFACTORY_TOKEN=
+----
+* Create and source an `environment` file for reuse.
++
+[source,bash]
+----
+envsubst < scripts/environment.template > scripts/environment
+. scripts/environment
+----
 
-
-==== Quick Start
-
-```bash
-git clone https://github.com/Cray-HPE/node-image-build.git
-cd node-image-build
-cp scripts/environment.template scripts/environment
-vim scripts/environment
-source scripts/environment
-mkdir -p iso
-wget https://<somepath>/SLE-15-SP3-Full-x86_64-GM-Media1.iso -O iso/SLE-15-SP3-Full-x86_64-GM-Media1.iso
-./scripts/setup.sh
-```
-
+[#_base_layer]
 ==== Base Layer
 
-The base layer will install SLES 15 and prepare the image for the installation of Kubernetes and Ceph.
+This requires following the <<_prerequisites>> section.
 
-Execute the following commands from the top level of the project
+.Steps for building
+. Download a base to start with, this example downloads a base ISO from CSM's Artifactory.
++
+[source,bash]
+----
+media=SLE-15-SP3-Online-x86_64-GM-Media1.iso
+mkdir iso
+curl -f -o iso/$media https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/os-images/${media}
+----
+. Render the `autoinst.xml` and `autoinst-google.xml` files.
++
+[source,bash]
+----
+./scripts/setup.sh
+----
+. Build.
++
+[source,bash]
+----
+packer build -only=qemu.sles15-base -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/sles15-base
+----
 
-To build with QEMU, run the following command.
+Once the images are built, the `.qcow2` and `.box` files will be placed in the `output-sles15-base` and `output-sles15-base-vagrant` directory, respectively.
 
-* Run `packer build -only=qemu.sles15-base -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/sles15-base/`
-
-To build with VirtualBox, run the following command.
-
-* Run `packer build -only=virtualbox-iso.sles15-base -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/sles15-base/`
-
-If you want to view the output of the build, disable `headless` mode:
-
-* Run `packer build -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' -var 'headless=false' boxes/sles15-base/`
-
-Once the images are built, the output will be placed in the `output-sles15-base` directory in the root of the project.
-
+[#_common_layer]
 ==== Common Layer
 
-The common layer starts from the output of the base layer. As such the base layer must be created before building common.
+If the <<_base_layer>> section was followed, then this layer can be built as is.If the base layer is being skipped, then a stable base needs to be downloaded.
 
-To build with QEMU, run the following command.
+.Steps for building
+. Download a stable base if one wasn't created by completing the <<_base_layer>> section.
++
+* Qemu
++
+[source,bash]
+----
+mkdir output-sles15-base
+curl -f -o output-sles15-base/sles15-base.qcow2 https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/stable/sles15-base/\\[RELEASE\\]/sles15-base-\\[RELEASE\\].qcow2
+----
+* Vagrant
++
+[source,bash]
+----
+mkdir output-sles15-base-vagrant
+curl -f -o output-sles15-base-vagrant/sles15-base.box https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/stable/sles15-base/\\[RELEASE\\]/sles15-base-\\[RELEASE\\].box
+----
++
+[sidebar]
+VirtualBox is not listed for two reasons; VirtualBox is not published to Artifactory, and VirtualBox uses the `.qcow2` file from qemu.
+. Build
+* Qemu
++
+[source,bash]
+----
+packer build -only=qemu.ncn-common -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/ncn-common
+----
+* VirtualBox
++
+[source,bash]
+----
+packer build -only=virtualbox-ovf.ncn-common -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/ncn-common
+----
 
-* Run `packer build -only=qemu.ncn-common -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/ncn-common/`
+Once the image has built, the `.qcow2` file will be placed in the `output-ncn-common` directory.
 
-To build with VirtualBox, run the following command.
+==== Pre-Install Toolkit Layer
 
-* Run `packer build -only=virtualbox-ovf.ncn-common -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/ncn-common/`
+If the <<_base_layer>> section was followed, then this layer can be built as is. If the base layer is being skipped, then a stable base needs to be downloaded.
 
-Once the image is built, the output will be placed in the `output-ncn-common` directory in the root of the project.
-
-==== Pit Common Layer
-
-The pit common layer starts from the output of the base layer. As such the base layer must be created before building pit common.
-
-To build with QEMU, run the following command.
-
-* Run `packer build -only=qemu.pit-common -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/pit-common/`
-
-To build with VirtualBox, run the following command.
-
-* Run `packer build -only=virtualbox-ovf.pit-common -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/pit-common/`
-
-Once the image is built, the output will be placed in the `output-pit-common` directory in the root of the project.
+.Steps for building
+. Download a stable base if one wasn't created by completing the <<_base_layer>> section.
++
+* Qemu
++
+[source,bash]
+----
+mkdir output-sles15-base
+curl -f -o output-sles15-base/sles15-base.qcow2 https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/stable/sles15-base/\\[RELEASE\\]/sles15-base-\\[RELEASE\\].qcow2
+----
++
+[sidebar]
+VirtualBox is not listed for two reasons; VirtualBox is not published to Artifactory, and VirtualBox uses the `.qcow2` file from qemu.
+. Build.
+* Qemu
++
+[source,bash]
+----
+packer build -only=qemu.pit-common -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/pit-common
+----
+* VirtualBox
++
+[source,bash]
+----
+packer build -only=virtualbox-ovf.pit-common -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/pit-common
+----
 
 ==== Non-Compute Node Image Layer
 
-The ncn-node-images stage builds on top of the common layer to create functional images for Kubernetes and Ceph.
+If the <<_common_layer>> section was followed, then this layer can be built as is. If the common layer is being skipped, then a stable common needs to be downloaded.
 
-To build with QEMU, run the following command.
+.Steps for building
+. Download a stable common if one wasn't created by completing the <<_common_layer>> section.
++
+* Qemu
++
+[source,bash]
+----
+mkdir output-ncn-common
+curl -f -o output-ncn-common-base/ncn-common.qcow2 https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/stable/ncn-common/\\[RELEASE\\]/ncn-common-\\[RELEASE\\].qcow2
+----
+. Build.
+* Qemu
++
+[source,bash]
+----
+packer build -only=qemu.* -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/ncn-node-images
+----
+* VirtualBox
++
+[source,bash]
+----
+packer build -only=virtualbox-ovf.* -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/ncn-node-images`
+----
 
-* Run `packer build -only=qemu.* -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/ncn-node-images/`
-
-To build with VirtualBox, run the following command.
-
-* Run `packer build -only=virtualbox-ovf.* -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/ncn-node-images/`
-
-Once the images are built, the output will be placed in the `output-sles15-images` directory in the root of the project.
-
-==== Vagrant
-
-Vagrant boxes are only configured to build from the output of the VirtualBox builds. In order to create Vagrant boxes
-you will first need to create the base image and the relevant node-image for Kubernetes and Ceph.
-
-To build vagrant boxes, run the following command:
-
-* Run `packer build -force -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD'; boxes/sles15-vagrant/`
-
-If you only want to build Kubernetes or Ceph, limit the build:
-
-* Run `packer build -only=virtualbox-ovf.kubernetes -force -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' boxes/sles15-vagrant/`
-
-If you want to view the output of the build, disable `headless` mode:
-
-* Run `packer build -force -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' -var 'headless=false' boxes/sles15-vagrant/`
-
-`# vagrant box add --force --name sles15sp3 ./sles15-base-virtualbox.box`
+Once the images has built, the `.qcow2` file will be placed in the `output-ncn-node-images` directory.
 
 === Artifacts
 
-Each layer creates a certain set of artifacts that can be used in different ways.
+Each layer creates a product, and each product is created in various formats. These formats cater to certain contexts.
 
-* Each layer creates a VM disk image that can be directly booted and/or used to create the next layer's image.
-* Each layer after `sles15-base` creates a list of packages and repos.
-* `ncn-common` creates kernel and initrd artifacts.
-* `ncn-node-images` creates kernel, initrd, and squashfs artifacts.
+.Artifact Types
+- Google artifacts (published directly to Google Cloud)
+- Metal artifacts (only produced by the last layer, `ncn-node-images`, and published to Artifactory)
+- VirtualBox artifacts (not built by any automation nor published anywhere)
+
+Each type is the _same_ with some exceptions.
+
+==== Latest Artifacts
+
+The latest artifacts can be fetched by the following commands.
+
+. Set the credentials
++
+[source,bash]
+----
+ARTIFACTORY_USER=<username>
+ARTFACTORY_TOKEN=<api token>
+----
+. Download the Artifacts
++
+[source,bash]
+----
+curl -f -o sles15-base.qcow2 https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/stable/sles15-base/\\[RELEASE\\]/sles15-base-\\[RELEASE\\].qcow2
+curl -f -o ncn-common.qcow2 https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/stable/ncn-common/\\[RELEASE\\]/ncn-common-\\[RELEASE\\].qcow2
+curl -f -o pit-common.qcow2 https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/stable/pit-common/\\[RELEASE\\]/pit-common-\\[RELEASE\\].qcow2
+curl -f -o kubernetes.qcow2 https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/stable/kubernetes/\\[RELEASE\\]/kubernetes-\\[RELEASE\\].qcow2
+curl -f -o storage-ceph.qcow2 https://$ARTIFACTORY_USER:$ARTIFACTORY_TOKEN@artifactory.algol60.net/artifactory/csm-images/stable/storage-ceph/\\[RELEASE\\]/storage-ceph-\\[RELEASE\\].qcow2
+----
 
 === Versioning
 
-* The version of the build is passed with the `packer build` command as the `artifact_version` var:
+The version of the build is passed with the `packer build` command as the `artifact_version` var. This
+is a unique identifier consisting of a shortened git hash and a datestamp.
 
-```bash
-packer build -only=qemu.sles15-base -var "artifact_version=`git rev-parse --short HEAD`" -var 'ssh_password=$SLES15_INITIAL_ROOT_PASSWORD' -var 'headless=false' boxes/sles15-base/
-````
-
-* If no version is passed to the builder then the version `none` is used when generating the archive.
+* If no version is passed to the builder then a version is generated in the format of `[COMMIT]-[TIMESTAMP]`.
+* Feature artifacts use the versioning format of `[COMMIT]-[TIMESTAMP]`.
+** These publish to `unstable`.
+* Pre-release artifacts use the versioning format of `A.B.C-X`, where `A.B.C` is the anticipated, stable release that this pre-release is for.
+** These publish to `unstable`.
+* A release artifact uses the versioning format of `A.B.C`.
+** These publish to `stable`.


### PR DESCRIPTION
Since there is no more `develop` branch, there's no need to mark PRs to `main` as "release".

Signed-off-by: Russell Bunch <doomslayer@hpe.com>
