### PR TITLE
Revert "CASMINST-5130: Add kubeadm identity configuration"

### DIFF
--- a/boxes/ncn-node-images/kubernetes/files/resources/common/encryption-configuration.yaml
+++ b/boxes/ncn-node-images/kubernetes/files/resources/common/encryption-configuration.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: apiserver.config.k8s.io/v1
-kind: EncryptionConfiguration
-resources:
-  - resources:
-      - secrets
-    providers:
-      - identity: {}

--- a/boxes/ncn-node-images/kubernetes/files/resources/common/kubeadm.cfg
+++ b/boxes/ncn-node-images/kubernetes/files/resources/common/kubeadm.cfg
@@ -38,7 +38,6 @@ apiServer:
     oidc-ca-file: "/etc/kubernetes/pki/oidc.pem"
     oidc-username-claim: "name"
     oidc-groups-claim: "groups"
-    encryption-provider-config: /etc/cray/kubernetes/encryption/current.yaml
 
 controllerManager:
   extraArgs: ${CONTROLLER_MANAGER_EXTRA_ARGS}


### PR DESCRIPTION
This reverts commit ffdec40f08149b362ac624c90b07755fe8250564.

### Summary and Scope

I got this to boot but restarting kubelet had issues. Instead of holding up others just revert this and I can test/validate on redbull myself.

- Fixes:
- Requires:
- Relates to:

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
