### PR TITLE
VSHA-420 - Add goss tests to pit, ceph and kubernetes images

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -522,6 +522,9 @@ pipeline {
             }
         }
         stage('Tests Results') {
+            when {
+                expression { env.TAG_NAME == null && (!(BRANCH_NAME ==~ promotionToken) || (BRANCH_NAME ==~ promotionToken && params.buildAndPublish)) }
+            }
             steps {
                 script {
                     sh "mkdir build-test-results && cp output*/test-results-*.xml build-test-results"

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -521,6 +521,14 @@ pipeline {
                 }
             }
         }
+        stage('Tests Results') {
+            steps {
+                script {
+                    sh "mkdir build-test-results && cp output*/test-results-*.xml build-test-results"
+                    junit 'build-test-results/test-results-*.xml'
+                }
+            }
+        }
         stage('Release') {
             when { tag "*" }
             steps {

--- a/boxes/ncn-node-images/kubernetes/files/tests/common/kubernetes-tests.yml
+++ b/boxes/ncn-node-images/kubernetes/files/tests/common/kubernetes-tests.yml
@@ -21,13 +21,148 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+file:
+  /etc/zypp/services.d/Basesystem_Module_15_SP2_x86_64.service:
+    exists: false
+  /etc/zypp/services.d/Server_Applications_Module_15_SP2_x86_64.service:
+    exists: false
+  /etc/zypp/services.d/Public_Cloud_Module_15_SP2_x86_64.service:
+    exists: false
+  /etc/zypp/services.d/SUSE_Linux_Enterprise_Server_15_SP2_x86_64.service:
+    exists: false
+  /var/adm/autoinstall/cache:
+    exists: false
+  /etc/kubernetes:
+    exists: true
+user:
+  sshd:
+    exists: true
+    groups:
+      - sshd
+    home: /var/lib/sshd
+    shell: /sbin/nologin
+group:
+  sshd:
+    exists: true
 service:
+  ca-certificates:
+    enabled: true
+    running: false
+  chronyd:
+    enabled: true
+    running: true
   containerd:
     enabled: true
     running: true
+  getty@tty1:
+    enabled: true
+    running: true
+  issue-generator:
+    enabled: true
+    running: false
   kubelet:
     enabled: true
     running: false
+  purge-kernels:
+    enabled: true
+    running: false
+  rc-local:
+    enabled: true
+    running: false
+  rollback:
+    enabled: true
+    running: false
+  sshd:
+    enabled: true
+    running: true
   spire-agent:
     enabled: true
     running: false
+  sshd:
+    enabled: true
+    running: true
+  wicked:
+    enabled: true
+    running: true
+  wickedd-auto4:
+    enabled: true
+    running: true
+  wickedd-dhcp4:
+    enabled: true
+    running: true
+  wickedd-dhcp6:
+    enabled: true
+    running: true
+  wickedd-nanny:
+    enabled: true
+    running: true
+process:
+  sshd:
+    running: true
+  dnsmasq:
+    running: false
+  cron:
+    running: true
+package:
+  curl:
+    installed: true
+  craycli:
+    installed: true
+  dnsmasq:
+    installed: true
+  ethtool:
+    installed: true
+  hpe-csm-goss-package:
+    installed: true
+  hpe-csm-scripts:
+    installed: true
+  hpe-csm-yq-package:
+    installed: true
+  ipmitool:
+    installed: true
+  kubectl:
+    installed: true
+  kubeadm:
+    installed: true
+  openssl:
+    installed: true
+  podman:
+    installed: true
+  rsync:
+    installed: true
+  tar:
+    installed: true
+  cray-cmstools-crayctldeploy:
+    installed: true
+  loftsman:
+    installed: true
+  manifestgen:
+    installed: true
+  cfs-trust:
+    installed: true
+  csm-node-identity:
+    installed: true
+  cfs-state-reporter:
+    installed: true
+  cray-heartbeat:
+    installed: true
+  platform-utils:
+    installed: true
+  libtiff5:
+    installed: true
+  cray-power-button:
+    installed: true
+  cray-prodmgr:
+    installed: true
+  cray-orca:
+    installed: true
+  cray-cps-utils:
+    installed: true
+  intlfonts-euro-bitmap-fonts:
+    installed: true
+  cray-sdu-rda:
+    installed: true
+  goss-servers:
+    installed: true
+  cray-auth-utils:
+    installed: true

--- a/boxes/ncn-node-images/node-images.pkr.hcl
+++ b/boxes/ncn-node-images/node-images.pkr.hcl
@@ -489,22 +489,22 @@ build {
   post-processors {
     post-processor "shell-local" {
       inline = [
-        "if grep '<failure>' ${var.output_directory}/test-results-common.xml ; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
-        "if grep '<failure>' ${var.output_directory}/test-results-${source.name}.xml ; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
+        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-common.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
+        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-${source.name}.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
       ]
     }
     post-processor "shell-local" {
       inline = [
-        "if grep '<failure>' ${var.output_directory}/test-results-ncn-google.xml ; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
-        "if grep '<failure>' ${var.output_directory}/test-results-${source.name}-google.xml ; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
+        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-ncn-google.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
+        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-${source.name}-google.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
       ]
       only = ["googlecompute.kubernetes"]
       #      only = ["googlecompute.kubernetes", "googlecompute.storage-ceph"]
     }
     post-processor "shell-local" {
       inline = [
-        "if grep '<failure>' ${var.output_directory}/test-results-ncn-metal.xml ; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
-        "if grep '<failure>' ${var.output_directory}/test-results-${source.name}-metal.xml ; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
+        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-ncn-metal.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
+        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-${source.name}-metal.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
       ]
       only = [
         "qemu.kubernetes", "virtualbox-ovf.kubernetes", "qemu.storage-ceph",

--- a/boxes/ncn-node-images/storage-ceph/files/tests/common/storage-ceph-tests.yml
+++ b/boxes/ncn-node-images/storage-ceph/files/tests/common/storage-ceph-tests.yml
@@ -21,13 +21,117 @@
 # ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+file:
+  /etc/zypp/services.d/Basesystem_Module_15_SP2_x86_64.service:
+    exists: false
+  /etc/zypp/services.d/Server_Applications_Module_15_SP2_x86_64.service:
+    exists: false
+  /etc/zypp/services.d/Public_Cloud_Module_15_SP2_x86_64.service:
+    exists: false
+  /etc/zypp/services.d/SUSE_Linux_Enterprise_Server_15_SP2_x86_64.service:
+    exists: false
+  /var/adm/autoinstall/cache:
+    exists: false
+  /etc/ceph:
+    exists: true
+user:
+  sshd:
+    exists: true
+    groups:
+      - sshd
+    home: /var/lib/sshd
+    shell: /sbin/nologin
+group:
+  sshd:
+    exists: true
 service:
-  podman.service:
+  chronyd:
+    enabled: true
+    running: true
+  ca-certificates:
+    enabled: true
+    running: false
+  issue-generator:
+    enabled: true
+    running: false
+  ca-certificates:
+    enabled: true
+    running: false
+  issue-generator:
+    enabled: true
+    running: false
+  purge-kernels:
+    enabled: true
+    running: false
+  rc-local:
+    enabled: true
+    running: false
+  rollback:
+    enabled: true
+    running: false
+  sshd:
+    enabled: true
+    running: true
+  wicked:
+    enabled: true
+    running: true
+  wickedd-auto4:
+    enabled: true
+    running: true
+  wickedd-dhcp4:
+    enabled: true
+    running: true
+  wickedd-dhcp6:
+    enabled: true
+    running: true
+  wickedd-nanny:
+    enabled: true
+    running: true
+  getty@tty1:
+    enabled: true
+    running: true
+  spire-agent:
     enabled: false
     running: false
-  registry.container.service:
-    enabled: false
+process:
+  sshd:
+    running: true
+  dnsmasq:
     running: false
-  spire-agent.service:
-    enabled: false
+  cron:
+    running: true
+  dnsmasq:
     running: false
+package:
+  cephadm:
+    installed: true
+  ceph-common:
+    installed: true
+  python3:
+    installed: true
+  curl:
+    installed: true
+  craycli:
+    installed: true
+  dnsmasq:
+    installed: true
+  ethtool:
+    installed: true
+  hpe-csm-goss-package:
+    installed: true
+  hpe-csm-scripts:
+    installed: true
+  hpe-csm-yq-package:
+    installed: true
+  ipmitool:
+    installed: true
+  kubectl:
+    installed: true
+  openssl:
+    installed: true
+  podman:
+    installed: true
+  rsync:
+    installed: true
+  tar:
+    installed: true

--- a/boxes/pit-common/files/tests/common/pit-common-tests.yml
+++ b/boxes/pit-common/files/tests/common/pit-common-tests.yml
@@ -1,3 +1,26 @@
+#
+# MIT License
+#
+# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+#
 file:
   /var/adm/autoinstall/cache:
     exists: false
@@ -20,3 +43,81 @@ service:
   sshd:
     enabled: true
     running: true
+user:
+  sshd:
+    exists: true
+    groups:
+      - sshd
+    home: /var/lib/sshd
+    shell: /sbin/nologin
+group:
+  sshd:
+    exists: true
+process:
+  nginx:
+    running: false
+  sshd:
+    running: true
+  dnsmasq:
+    running: false
+  httpd-prefork:
+    running: false
+  chronyd:
+    running: false
+  cron:
+    running: true
+  dnsmasq:
+    running: false
+  java:
+    running: false
+package:
+  apache2:
+    installed: true
+  canu:
+    installed: true
+  curl:
+    installed: true
+  craycli:
+    installed: true
+  cray-site-init:
+    installed: true
+  dnsmasq:
+    installed: true
+  ethtool:
+    installed: true
+  git-core:
+    installed: true
+  hpe-csm-goss-package:
+    installed: true
+  hpe-csm-scripts:
+    installed: true
+  hpe-csm-yq-package:
+    installed: true
+  ipmitool:
+    installed: true
+  ilorest:
+    installed: true
+  kubectl:
+    installed: true
+  loftsman:
+    installed: true
+  manifestgen:
+    installed: true
+  metal-basecamp:
+    installed: true
+  metal-ipxe:
+    installed: true
+  metal-net-scripts:
+    installed: true
+  openssl:
+    installed: true
+  pit-init:
+    installed: true
+  pit-nexus:
+    installed: true
+  podman:
+    installed: true
+  rsync:
+    installed: true
+  tar:
+    installed: true

--- a/boxes/pit-common/pit-common.pkr.hcl
+++ b/boxes/pit-common/pit-common.pkr.hcl
@@ -254,18 +254,18 @@ build {
   post-processors {
     post-processor "shell-local" {
       inline = [
-        "if grep '<failure>' ${var.output_directory}/test-results.xml ; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
+        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
       ]
     }
     post-processor "shell-local" {
       inline = [
-        "if grep '<failure>' ${var.output_directory}/test-results-google.xml ; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
+        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-google.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
       ]
       only = ["googlecompute.pit-common"]
     }
     post-processor "shell-local" {
       inline = [
-        "if grep '<failure>' ${var.output_directory}/test-results-metal.xml ; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
+        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-metal.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
       ]
       only = ["qemu.pit-common", "virtualbox-ovf.ncn-common"]
     }


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: VSHA-220, VSHA-421

#### Issue Type

<!--- Delete un-needed bullets -->

- Improve build tests
- Add validation before liveCD tests

When builds are complete the build pipeline should automatically test those images
The image should be launched, and Goss tests should be run to validate the image contents.

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
