### PR TITLE
CASMINST-5130

### DIFF
--- a/boxes/ncn-node-images/kubernetes/files/resources/common/encryption-configuration.yaml
+++ b/boxes/ncn-node-images/kubernetes/files/resources/common/encryption-configuration.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+      - secrets
+    providers:
+      - identity: {}

--- a/boxes/ncn-node-images/kubernetes/files/resources/common/kubeadm.cfg
+++ b/boxes/ncn-node-images/kubernetes/files/resources/common/kubeadm.cfg
@@ -38,6 +38,7 @@ apiServer:
     oidc-ca-file: "/etc/kubernetes/pki/oidc.pem"
     oidc-username-claim: "name"
     oidc-groups-claim: "groups"
+    encryption-provider-config: /etc/cray/kubernetes/encryption/current.yaml
 
 controllerManager:
   extraArgs: ${CONTROLLER_MANAGER_EXTRA_ARGS}

--- a/boxes/ncn-node-images/kubernetes/files/resources/common/kubeadm.cfg
+++ b/boxes/ncn-node-images/kubernetes/files/resources/common/kubeadm.cfg
@@ -39,7 +39,12 @@ apiServer:
     oidc-username-claim: "name"
     oidc-groups-claim: "groups"
     encryption-provider-config: /etc/cray/kubernetes/encryption/current.yaml
-
+  extraVolumes:
+    - name: k8s-encryption
+      hostPath: /etc/cray/kubernetes/encryption
+      mountPath: /etc/cray/kubernetes/encryption
+      pathType: DirectoryOrCreate
+      readOnly: true
 controllerManager:
   extraArgs: ${CONTROLLER_MANAGER_EXTRA_ARGS}
   extraVolumes:

--- a/boxes/ncn-node-images/kubernetes/files/scripts/common/kubernetes-cloudinit.sh
+++ b/boxes/ncn-node-images/kubernetes/files/scripts/common/kubernetes-cloudinit.sh
@@ -37,6 +37,9 @@ export ETCD_INITIAL_CLUSTER_STRING=$(get-etcd-initial-cluster-members)
 export ETCDCTL_BACKUP_ENDPOINTS=$(get-etcdctl-backup-endpoints)
 initialized_file="/etc/cray/kubernetes/initialized"
 
+# Script constants to reduce copypasta
+K8S_PREFIX=/etc/cray/kubernetes
+
 #
 # Expand the root disk (vshasta only)
 #
@@ -91,6 +94,24 @@ function wait-for-remote-file() {
   done
 }
 
+# Only applicable to control plane nodes, sets up
+# /etc/cray/kubernetes/encryption as needed as the kubelet process now has a
+# switch that requires the files to be present when things are started.
+function setup-encryption() {
+  # Note encryption files/setup is in its own sub directory to ensure the
+  # daemonset doesn't need to possibly have access to any other data than it
+  # truly needs.
+  echo "Installing default encryption configuration setup"
+  k8s_encryptiondir="${K8S_PREFIX}/encryption"
+  install -dm755 "${k8s_encryptiondir}"
+  install -dm400 /srv/cray/resources/common/encryption-configuration.yaml "${k8s_encryptiondir}/default.yaml"
+
+  # This is a nop setup for now, the current encryption is default/identity
+  # encryption which doesn't differ with anything today. Just lets etcd writes
+  # to go through the encryption machinery.
+  ln -sf "${k8s_encryptiondir}/default.yaml" "${k8s_encryptiondir}/current.yaml"
+}
+
 function join() {
   local join_script_remote="$1"
   local join_script_local="/etc/cray/kubernetes/join.sh"
@@ -102,6 +123,8 @@ function join() {
   #
   if [[ "$(hostname)" =~ ^ncn-m ]]; then
     echo "$(cat ${join_script_local}) --apiserver-advertise-address=${K8S_NODE_IP}" > ${join_script_local}
+    # All other control-plane nodes need encryption setups as well.
+    setup-encryption
   fi
 
   chmod 0700 $join_script_local
@@ -403,6 +426,8 @@ if [[ "$(hostname)" == $FIRST_MASTER_HOSTNAME ]] || [[ "$(hostname)" =~ ^$FIRST_
   export CERTIFICATE_KEY=$(cat /etc/cray/kubernetes/certificate-key)
 
   configure-load-balancer-for-master
+
+  setup-encryption
 
   envsubst < /srv/cray/resources/common/kubeadm.cfg > /etc/cray/kubernetes/kubeadm.yaml
   echo "Initializing Kubernetes on the first control plane node, pod cidr $PODS_CIDR, service cidr $SERVICES_CIDR"


### PR DESCRIPTION
### Summary and Scope

Fixes for the issues seen with the smoketest

- Fixes: CASMINST-5130
- Requires:
- Relates to:

#### Issue Type

- RFE Pull Request

Reverts the revert and fixes the issues seen with redbull.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [x ] I tested this on internal system redbull, I pulled in the images and then rebooted both nodes and ensured we can cloud-init into k8s successfully. I tested out a couple other scenarios aka restarting kubelet after etc...)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
n/a
 
### Risks and Mitigations

Need the kubeadm.cfg changes in so they can be used by a daemonset that mounts the directory they are in. As well as need the volume mounts in place for the kubeapi so that we can make it possible to add api encryption on the fly without node image changes.