### PR TITLE
MTL-1905 single kernel

### DIFF
--- a/boxes/ncn-common/provisioners/common/cleanup.sh
+++ b/boxes/ncn-common/provisioners/common/cleanup.sh
@@ -37,6 +37,7 @@ function kernel {
     current_kernel="$(grep kernel-default /srv/cray/csm-rpms/packages/node-image-non-compute-common/base.packages | awk -F '=' '{print $NF}')"
 
     echo "Purging old kernels ... "
+    zypper removelock kernel-default || echo 'No lock to remove'
     sed -i 's/^multiversion.kernels =.*/multiversion.kernels = '"${current_kernel}"'/g' /etc/zypp/zypp.conf
     zypper --non-interactive purge-kernels --details
 
@@ -44,7 +45,7 @@ function kernel {
     zypper addlock kernel-default && zypper locks
         
     echo "Listing currently installed kernel-default RPM:"
-    rpm -qa | grep kernel-default
+    rpm -q kernel-default
 }
 kernel
 

--- a/boxes/ncn-node-images/node-images.pkr.hcl
+++ b/boxes/ncn-node-images/node-images.pkr.hcl
@@ -400,6 +400,13 @@ build {
   provisioner "shell" {
     inline = [
       "bash -c 'goss -g /srv/cray/tests/google/ncn-common-tests.yml validate -f junit | tee /tmp/goss_google_out.xml'",
+    ]
+    only = ["googlecompute.kubernetes", "googlecompute.storage-ceph"]
+  }
+
+  // storage-ceph does not have Google specific tests at this time.
+  provisioner "shell" {
+    inline = [
       "bash -c 'goss -g /srv/cray/tests/google/${source.name}-tests.yml validate -f junit | tee /tmp/goss_${source.name}_google_out.xml'"
     ]
     only = ["googlecompute.kubernetes"]
@@ -420,27 +427,27 @@ build {
   provisioner "file" {
     direction   = "download"
     source      = "/tmp/goss_common_out.xml"
-    destination = "${var.output_directory}/test-results-common.xml"
+    destination = "${var.output_directory}/${source.name}/test-results-common.xml"
   }
 
   provisioner "file" {
     direction   = "download"
     source      = "/tmp/goss_${source.name}_out.xml"
-    destination = "${var.output_directory}/test-results-${source.name}.xml"
+    destination = "${var.output_directory}/${source.name}/test-results-${source.name}.xml"
   }
 
   provisioner "file" {
     direction   = "download"
     source      = "/tmp/goss_google_out.xml"
-    destination = "${var.output_directory}/test-results-ncn-google.xml"
-    only        = ["googlecompute.kubernetes"]
-    #    only        = ["googlecompute.kubernetes", "googlecompute.storage-ceph"]
+    destination = "${var.output_directory}/${source.name}/test-results-ncn-google.xml"
+    only        = ["googlecompute.kubernetes", "googlecompute.storage-ceph"]
   }
 
+  // storage-ceph does not have Google specific tests at this time.
   provisioner "file" {
     direction   = "download"
     source      = "/tmp/goss_${source.name}_google_out.xml"
-    destination = "${var.output_directory}/test-results-${source.name}-google.xml"
+    destination = "${var.output_directory}/${source.name}/test-results-${source.name}-google.xml"
     only        = ["googlecompute.kubernetes"]
     #    only        = ["googlecompute.kubernetes", "googlecompute.storage-ceph"]
   }
@@ -448,7 +455,7 @@ build {
   provisioner "file" {
     direction   = "download"
     source      = "/tmp/goss_metal_out.xml"
-    destination = "${var.output_directory}/test-results-ncn-metal.xml"
+    destination = "${var.output_directory}/${source.name}/test-results-ncn-metal.xml"
     only        = [
       "qemu.kubernetes", "virtualbox-ovf.kubernetes", "qemu.storage-ceph",
       "virtualbox-ovf.storage-ceph"
@@ -458,7 +465,7 @@ build {
   provisioner "file" {
     direction   = "download"
     source      = "/tmp/goss_${source.name}_metal_out.xml"
-    destination = "${var.output_directory}/test-results-${source.name}-metal.xml"
+    destination = "${var.output_directory}/${source.name}/test-results-${source.name}-metal.xml"
     only        = [
       "qemu.kubernetes", "virtualbox-ovf.kubernetes", "qemu.storage-ceph",
       "virtualbox-ovf.storage-ceph"
@@ -489,27 +496,28 @@ build {
   post-processors {
     post-processor "shell-local" {
       inline = [
-        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-common.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
-        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-${source.name}.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
+        "if ! grep ' failures=.0. ' ${var.output_directory}/${source.name}/test-results-common.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
+        "if ! grep ' failures=.0. ' ${var.output_directory}/${source.name}/test-results-${source.name}.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
       ]
     }
     post-processor "shell-local" {
       inline = [
-        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-ncn-google.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
+        "if ! grep ' failures=.0. ' ${var.output_directory}/${source.name}/test-results-ncn-google.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
       ]
       only = ["googlecompute.kubernetes", "googlecompute.storage-ceph"]
     }
+    // storage-ceph does not have Google specific tests at this time, but it does have general ncn-google tests.
     post-processor "shell-local" {
       inline = [
-        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-${source.name}-google.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
+        "if ! grep ' failures=.0. ' ${var.output_directory}/${source.name}/test-results-${source.name}-google.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
       ]
       only = ["googlecompute.kubernetes"]
       #      only = ["googlecompute.kubernetes", "googlecompute.storage-ceph"]
     }
     post-processor "shell-local" {
       inline = [
-        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-ncn-metal.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
-        "if ! grep ' failures=.0. ' ${var.output_directory}/test-results-${source.name}-metal.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
+        "if ! grep ' failures=.0. ' ${var.output_directory}/${source.name}/test-results-ncn-metal.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi",
+        "if ! grep ' failures=.0. ' ${var.output_directory}/${source.name}/test-results-${source.name}-metal.xml; then echo >&2 'Error: goss test failures found! See build output for details'; exit 1; fi"
       ]
       only = [
         "qemu.kubernetes", "virtualbox-ovf.kubernetes", "qemu.storage-ceph",

--- a/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common/files/tests/common/ncn-common-tests.yml
+++ b/vendor/github.com/Cray-HPE/metal-provision/roles/ncn-common/files/tests/common/ncn-common-tests.yml
@@ -43,6 +43,13 @@ command:
     stdout:
     - 0
     skip: false
+  single_kernel:
+    exit-status: 0
+    # due to pipe, exit status will be zero
+    exec: "rpm -q kernel-default | wc -l"
+    stdout:
+    - 1
+    skip: false
 service:
   ca-certificates:
     enabled: true


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1905

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
`zypper purge-kernels` was failing because when it's invoked there's a `zypper lock` on `kernel-default`. The lock prevents `purge-kernels` from actually purging undesirable kernels.

This also adds a test to ensure we do not hit this again.
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
