### PR TITLE
MTL-1906: ensure kata and containerd tarball unpack with root ownership

### DIFF
--- a/boxes/ncn-node-images/kubernetes/files/tests/common/kubernetes-tests.yml
+++ b/boxes/ncn-node-images/kubernetes/files/tests/common/kubernetes-tests.yml
@@ -34,6 +34,10 @@ file:
     exists: false
   /etc/kubernetes:
     exists: true
+  /:
+    exists: true
+    owner: root
+    group: root
 user:
   sshd:
     exists: true

--- a/boxes/ncn-node-images/kubernetes/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/kubernetes/provisioners/common/install.sh
@@ -38,7 +38,12 @@ mkdir -p /var/run/sds
 echo "${KUBERNETES_PULL_VERSION}" > /etc/cray/kubernetes/version
 
 echo "Installing kata containers"
-wget -q -c https://github.com/kata-containers/kata-containers/releases/download/${KATA_VERSION}/kata-static-${KATA_VERSION}-x86_64.tar.xz -O - | tar -xJ -C /
+wget -q -c -O /tmp/kata-static.tar.xz https://github.com/kata-containers/kata-containers/releases/download/${KATA_VERSION}/kata-static-${KATA_VERSION}-x86_64.tar.xz
+tar -xJf /tmp/kata-static.tar.xz -C /
+sudo chown root.root /
+# shellcheck disable=SC2086,SC2046
+sudo chown root.root $(tar tJf /tmp/kata-static.tar.xz | sed 's|^|/|g' | xargs echo)
+rm /tmp/kata-static.tar.xz
 
 echo "Installing etcd binaries"
 mkdir -p /tmp/etcd
@@ -83,6 +88,9 @@ echo "Ensuring swap is off" && swapoff -a
 echo "Installing containerd CRI and configuring the system for containerd"
 wget -q -O /tmp/cri-containerd.tar.gz https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz
 tar --no-overwrite-dir -C / -xvzf /tmp/cri-containerd.tar.gz
+sudo chown root.root /
+# shellcheck disable=SC2086,SC2046
+sudo chown root.root $(tar tzf /tmp/cri-containerd.tar.gz | sed 's|^|/|g' | xargs echo)
 rm /tmp/cri-containerd.tar.gz
 ln -svnf /srv/cray/resources/common/containerd/containerd.service /etc/systemd/system/containerd.service
 mkdir -p /etc/containerd

--- a/boxes/ncn-node-images/storage-ceph/files/tests/common/storage-ceph-tests.yml
+++ b/boxes/ncn-node-images/storage-ceph/files/tests/common/storage-ceph-tests.yml
@@ -34,6 +34,10 @@ file:
     exists: false
   /etc/ceph:
     exists: true
+  /:
+    exists: true
+    owner: root
+    group: root
 user:
   sshd:
     exists: true


### PR DESCRIPTION
### Summary and Scope

Ensure kata and containerd tarball unpack with root ownership, add goss test to confirm

- Fixes: MTL-1906


#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
