### PR TITLE
MTL-1910 Remove extra `packer init` calls

### DIFF
--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -52,6 +52,7 @@ if (env.BRANCH_NAME ==~ ~"^PR-\\d+") {
     return
 }
 
+def artifactoryURL = 'https://artifactory.algol60.net/artifactory'
 pipeline {
     agent {
         label "metal-gcp-builder-large"
@@ -70,10 +71,10 @@ pipeline {
         ARTIFACTS_DIRECTORY_PIT = "output-ncn-node-images/pre-install-toolkit"
         ARTIFACTS_DIRECTORY_CEPH = "output-ncn-node-images/storage-ceph"
         ISO = "SLE-15-SP3-Online-x86_64-GM-Media1.iso"
-        ISO_URL = "https://artifactory.algol60.net/artifactory/os-images"
+        ISO_URL = "${artifactoryURL}/os-images"
         NPROC = sh(returnStdout: true, script: "nproc").trim()
         NRAM = '8196'
-        STABLE_BASE = "https://artifactory.algol60.net/artifactory/csm-images/stable"
+        STABLE_BASE = "${artifactoryURL}/csm-images/stable"
         VERSION = setImageVersion(commitHashShort: GIT_COMMIT[0..6])
     }
 
@@ -172,35 +173,40 @@ pipeline {
                             script {
 
                                 def base = "sles15-base"
-                                def googleSourceArtifact = "vshasta-${base}-${VERSION}"
                                 def googleSourceImageFamily = "vshasta-${base}"
-                                def sourceImage = "${base}-${VERSION}"
+                                def googleSourceArtifact
+                                def sourceArtifact
                                 def arguments
                                 def props
-                                def source = "${ARTIFACTS_DIRECTORY_BASE}/${sourceImage}"
+                                def source
 
+                                // If the previous layer wasn't built in this job, resolve the artifacts.
                                 if (!params.rebuildBaseLayers) {
-                                    source = "${STABLE_BASE}/${base}/${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}/${base}-${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}"
+                                    // If we're not pulling the latest artifact, resolve the necessary IDs.
                                     if (sourceBuildVersion != "[RELEASE]") {
                                         source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, sourceBuildVersion)
+                                        sourceArtifact = "${base}-${sourceBuildVersion}"
                                         googleSourceArtifact = nodeImageHelpers.getGoogleCloudSourceArtifactFromId(googleSourceImageFamily, sourceBuildVersion)
+                                        // If we are pulling the latest artifact, resolve th enecessary IDs.
                                     } else {
-                                        googleSourceArtifact = getGoogleCloudSourceArtifact(
-                                                googleCloudSaKey: GOOGLE_CLOUD_SA_KEY,
-                                                googleCloudProject: params.googleSourceImageProjectId,
-                                                googleCloudFamily: googleSourceImageFamily
-                                        )
+                                        source = "${STABLE_BASE}/${base}/${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}/${base}-${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}"
+                                        response = httpRequest(authentication: 'artifactory-algol60', url: "${artifactoryURL}/api/search/latestVersion?g=stable&a=${base}")
+                                        sourceArtifactVersion = response.content
+                                        sourceArtifact = "${base}-${sourceArtifactVersion}"
+                                        googleSourceArtifact = "vshasta-${base}-${sourceArtifactVersion.replaceAll("\\.", "-")}"
                                     }
                                     dir("${env.ARTIFACTS_DIRECTORY_BASE}-qemu") {
-                                        httpRequest(authentication: 'artifactory-algol60', outputFile: "${sourceImage}.qcow2", responseHandle: 'NONE', url: "${source}.qcow2")
+                                        httpRequest(authentication: 'artifactory-algol60', outputFile: "${sourceArtifact}.qcow2", responseHandle: 'NONE', url: "${source}.qcow2")
                                     }
+                                } else {
+                                    // If the previous layer was built, then use that local artifact.
+                                    sourceArtifact = "${base}-${VERSION}"
+                                    googleSourceArtifact = "vshasta-${base}-${VERSION}"
                                 }
-
-                                arguments = "-except=virtualbox-ovf.* -only='*.ncn-common' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_BASE}-qemu/${sourceImage}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                arguments = "-except=virtualbox-ovf.* -only='*.ncn-common' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_BASE}-qemu/${sourceArtifact}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(arguments, 'boxes/ncn-common/')
                                 publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_COMMON}-qemu", VERSION)
-                                
-                                props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${sourceImage}"
+                                props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${sourceArtifact}"
                                 publishCsmImages(pattern: "${ARTIFACTS_DIRECTORY_COMMON}-qemu", imageName: 'ncn-common', version: env.VERSION, props: props)
                             }
                         }
@@ -224,35 +230,40 @@ pipeline {
                             script {
                                 
                                 def base = "ncn-common"
-                                def googleSourceArtifact = "vshasta-${base}-${VERSION}"
                                 def googleSourceImageFamily = "vshasta-${base}"
-                                def sourceImage = "${base}-${VERSION}"
+                                def googleSourceArtifact
+                                def sourceArtifact
                                 def arguments
                                 def props
-                                def source = "${ARTIFACTS_DIRECTORY_COMMON}/${sourceImage}"
+                                def source
 
+                                // If the previous layer wasn't built in this job, resolve the artifacts.
                                 if (!params.rebuildCommonLayers) {
-                                    source = "${STABLE_BASE}/${base}/${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}/${base}-${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}"
+                                    // If we're not pulling the latest artifact, resolve the necessary IDs.
                                     if (sourceBuildVersion != "[RELEASE]") {
                                         source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, sourceBuildVersion)
+                                        sourceArtifact = "${base}-${sourceBuildVersion}"
                                         googleSourceArtifact = nodeImageHelpers.getGoogleCloudSourceArtifactFromId(googleSourceImageFamily, sourceBuildVersion)
+                                        // If we are pulling the latest artifact, resolve th enecessary IDs.
                                     } else {
-                                        googleSourceArtifact = getGoogleCloudSourceArtifact(
-                                                googleCloudSaKey: GOOGLE_CLOUD_SA_KEY,
-                                                googleCloudProject: params.googleSourceImageProjectId,
-                                                googleCloudFamily: googleSourceImageFamily
-                                        )
+                                        source = "${STABLE_BASE}/${base}/${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}/${base}-${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}"
+                                        response = httpRequest(authentication: 'artifactory-algol60', url: "${artifactoryURL}/api/search/latestVersion?g=stable&a=${base}")
+                                        sourceArtifactVersion = response.content
+                                        sourceArtifact = "${base}-${sourceArtifactVersion}"
+                                        googleSourceArtifact = "vshasta-${base}-${sourceArtifactVersion.replaceAll("\\.", "-")}"
                                     }
                                     dir("${env.ARTIFACTS_DIRECTORY_COMMON}-qemu") {
-                                        httpRequest(authentication: 'artifactory-algol60', outputFile: "${sourceImage}.qcow2", responseHandle: 'NONE', url: "${source}.qcow2")
+                                        httpRequest(authentication: 'artifactory-algol60', outputFile: "${sourceArtifact}.qcow2", responseHandle: 'NONE', url: "${source}.qcow2")
                                     }
+                                } else {
+                                    // If the previous layer was built, then use that local artifact.
+                                    sourceArtifact = "${base}-${VERSION}"
+                                    googleSourceArtifact = "vshasta-${base}-${VERSION}"
                                 }
-
-                                arguments = "-except='virtualbox-ovf.*' -only='*.kubernetes' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_COMMON}-qemu/${sourceImage}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                arguments = "-except='virtualbox-ovf.*' -only='*.kubernetes' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_COMMON}-qemu/${sourceArtifact}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
                                 publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_K8S}-qemu", env.VERSION)
-
-                                props = "build.number=${VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${sourceImage}"
+                                props = "build.number=${VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${sourceArtifact}"
                                 publishCsmImages(pattern: "${ARTIFACTS_DIRECTORY_K8S}-qemu", imageName: 'kubernetes', version: env.VERSION, props: props)
                             }
                         }
@@ -286,34 +297,40 @@ pipeline {
                             script {
 
                                 def base = "ncn-common"
-                                def googleSourceArtifact = "vshasta-${base}-${VERSION}"
                                 def googleSourceImageFamily = "vshasta-${base}"
-                                def sourceImage = "${base}-${VERSION}"
+                                def googleSourceArtifact
+                                def sourceArtifact
                                 def arguments
                                 def props
-                                def source = "${ARTIFACTS_DIRECTORY_COMMON}/${sourceImage}"
+                                def source
 
-                                if (!params.rebuildBaseLayers) {
-                                    source = "${STABLE_BASE}/${base}/${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}/${base}-${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}"
+                                // If the previous layer wasn't built in this job, resolve the artifacts.
+                                if (!params.rebuildCommonLayers) {
+                                    // If we're not pulling the latest artifact, resolve the necessary IDs.
                                     if (sourceBuildVersion != "[RELEASE]") {
                                         source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, sourceBuildVersion)
+                                        sourceArtifact = "${base}-${sourceBuildVersion}"
                                         googleSourceArtifact = nodeImageHelpers.getGoogleCloudSourceArtifactFromId(googleSourceImageFamily, sourceBuildVersion)
+                                        // If we are pulling the latest artifact, resolve th enecessary IDs.
                                     } else {
-                                        googleSourceArtifact = getGoogleCloudSourceArtifact(
-                                                googleCloudSaKey: GOOGLE_CLOUD_SA_KEY,
-                                                googleCloudProject: params.googleSourceImageProjectId,
-                                                googleCloudFamily: googleSourceImageFamily
-                                        )
+                                        source = "${STABLE_BASE}/${base}/${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}/${base}-${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}"
+                                        response = httpRequest(authentication: 'artifactory-algol60', url: "${artifactoryURL}/api/search/latestVersion?g=stable&a=${base}")
+                                        sourceArtifactVersion = response.content
+                                        sourceArtifact = "${base}-${sourceArtifactVersion}"
+                                        googleSourceArtifact = "vshasta-${base}-${sourceArtifactVersion.replaceAll("\\.", "-")}"
                                     }
                                     dir("${env.ARTIFACTS_DIRECTORY_COMMON}-qemu") {
-                                        httpRequest(authentication: 'artifactory-algol60', outputFile: "${sourceImage}.qcow2", responseHandle: 'NONE', url: "${source}.qcow2")
+                                        httpRequest(authentication: 'artifactory-algol60', outputFile: "${sourceArtifact}.qcow2", responseHandle: 'NONE', url: "${source}.qcow2")
                                     }
+                                } else {
+                                    // If the previous layer was built, then use that local artifact.
+                                    sourceArtifact = "${base}-${VERSION}"
+                                    googleSourceArtifact = "vshasta-${base}-${VERSION}"
                                 }
-
-                                arguments = "-except='virtualbox-ovf.*' -only='*.pre-install-toolkit' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_COMMON}-qemu/${sourceImage}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                arguments = "-except='virtualbox-ovf.*' -only='*.pre-install-toolkit' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_COMMON}-qemu/${sourceArtifact}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
                                 publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_PIT}-qemu", env.VERSION)
-                                props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${sourceImage}"
+                                props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${sourceArtifact}"
                                 publishCsmImages(pattern: "${ARTIFACTS_DIRECTORY_PIT}-qemu", imageName: 'pre-install-toolkit', version: env.VERSION, props: props)
                             }
                         }
@@ -330,34 +347,40 @@ pipeline {
                             script {
 
                                 def base = "ncn-common"
-                                def googleSourceArtifact = "vshasta-${base}-${VERSION}"
                                 def googleSourceImageFamily = "vshasta-${base}"
-                                def sourceImage = "${base}-${VERSION}"
+                                def googleSourceArtifact
+                                def sourceArtifact
                                 def arguments
                                 def props
-                                def source = "${ARTIFACTS_DIRECTORY_COMMON}/${base}"
+                                def source
 
+                                // If the previous layer wasn't built in this job, resolve the artifacts.
                                 if (!params.rebuildCommonLayers) {
-                                    source = "${STABLE_BASE}/${base}/${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}/${base}-${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}"
+                                    // If we're not pulling the latest artifact, resolve the necessary IDs.
                                     if (sourceBuildVersion != "[RELEASE]") {
                                         source = nodeImageHelpers.getArtifactorySourceArtifactFromId(source, sourceBuildVersion)
+                                        sourceArtifact = "${base}-${sourceBuildVersion}"
                                         googleSourceArtifact = nodeImageHelpers.getGoogleCloudSourceArtifactFromId(googleSourceImageFamily, sourceBuildVersion)
+                                        // If we are pulling the latest artifact, resolve th enecessary IDs.
                                     } else {
-                                        googleSourceArtifact = getGoogleCloudSourceArtifact(
-                                                googleCloudSaKey: GOOGLE_CLOUD_SA_KEY,
-                                                googleCloudProject: params.googleSourceImageProjectId,
-                                                googleCloudFamily: googleSourceImageFamily
-                                        )
+                                        source = "${STABLE_BASE}/${base}/${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}/${base}-${java.net.URLEncoder.encode("${sourceBuildVersion}", "UTF-8")}"
+                                        response = httpRequest(authentication: 'artifactory-algol60', url: "${artifactoryURL}/api/search/latestVersion?g=stable&a=${base}")
+                                        sourceArtifactVersion = response.content
+                                        sourceArtifact = "${base}-${sourceArtifactVersion}"
+                                        googleSourceArtifact = "vshasta-${base}-${sourceArtifactVersion.replaceAll("\\.", "-")}"
                                     }
                                     dir("${env.ARTIFACTS_DIRECTORY_COMMON}-qemu") {
-                                        httpRequest(authentication: 'artifactory-algol60', outputFile: "${sourceImage}.qcow2", responseHandle: 'NONE', url: "${source}.qcow2")
+                                        httpRequest(authentication: 'artifactory-algol60', outputFile: "${sourceArtifact}.qcow2", responseHandle: 'NONE', url: "${source}.qcow2")
                                     }
+                                } else {
+                                    // If the previous layer was built, then use that local artifact.
+                                    sourceArtifact = "${base}-${VERSION}"
+                                    googleSourceArtifact = "vshasta-${base}-${VERSION}"
                                 }
-
-                                arguments = "-except='virtualbox-ovf.*' --only='*.storage-ceph' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_COMMON}-qemu/${sourceImage}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
+                                arguments = "-except='virtualbox-ovf.*' --only='*.storage-ceph' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_COMMON}-qemu/${sourceArtifact}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
                                 publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
                                 publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_CEPH}-qemu", env.VERSION)
-                                props = "build.number=${VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${sourceImage}"
+                                props = "build.number=${VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${sourceArtifact}"
                                 publishCsmImages(pattern: "${ARTIFACTS_DIRECTORY_CEPH}-qemu", imageName: 'storage-ceph', version: env.VERSION, props: props)
                             }
                         }

--- a/Jenkinsfile.github
+++ b/Jenkinsfile.github
@@ -111,10 +111,15 @@ pipeline {
                     steps {
                         script {
                             dir('iso') {
-                                script {
-                                    httpRequest(authentication: 'artifactory-algol60', outputFile: "${ISO}", responseHandle: 'NONE', url: "${env.ISO_URL}/${env.ISO}")
-                                }
+                                httpRequest(authentication: 'artifactory-algol60', outputFile: "${ISO}", responseHandle: 'NONE', url: "${env.ISO_URL}/${env.ISO}")
                             }
+                        }
+                    }
+                }
+                stage('Packer Plugins') {
+                    steps {
+                        script {
+                            sh 'packer init boxes/ncn-node-images/variables.pkr.hcl'
                         }
                     }
                 }
@@ -135,7 +140,6 @@ pipeline {
                             script {
                                 def arguments
                                 arguments = "-except=virtualbox-iso.* -var 'source_iso_uri=iso/${env.ISO}' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-                                sh 'packer init boxes/sles15-base/'
                                 publishCsmImages.build(arguments, 'boxes/sles15-base/')
                                 publishCsmImages.prepareArtifacts("${env.ARTIFACTS_DIRECTORY_BASE}-qemu", VERSION)
                                 publishCsmImages.prepareArtifacts("${env.ARTIFACTS_DIRECTORY_BASE}-google", VERSION)
@@ -193,7 +197,6 @@ pipeline {
                                 }
 
                                 arguments = "-except=virtualbox-ovf.* -only='*.ncn-common' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_BASE}-qemu/${sourceImage}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-                                sh 'packer init boxes/ncn-common/'
                                 publishCsmImages.build(arguments, 'boxes/ncn-common/')
                                 publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_COMMON}-qemu", VERSION)
                                 
@@ -246,7 +249,6 @@ pipeline {
                                 }
 
                                 arguments = "-except='virtualbox-ovf.*' -only='*.kubernetes' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_COMMON}-qemu/${sourceImage}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-                                sh 'packer init boxes/ncn-node-images/variables.pkr.hcl'
                                 publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
                                 publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_K8S}-qemu", env.VERSION)
 
@@ -309,7 +311,6 @@ pipeline {
                                 }
 
                                 arguments = "-except='virtualbox-ovf.*' -only='*.pre-install-toolkit' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_COMMON}-qemu/${sourceImage}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-                                sh 'packer init boxes/ncn-node-images/variables.pkr.hcl'
                                 publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
                                 publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_PIT}-qemu", env.VERSION)
                                 props = "build.number=${env.VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${sourceImage}"
@@ -354,7 +355,6 @@ pipeline {
                                 }
 
                                 arguments = "-except='virtualbox-ovf.*' --only='*.storage-ceph' -var 'google_source_image_name=${googleSourceArtifact}' -var 'source_iso_uri=${env.ARTIFACTS_DIRECTORY_COMMON}-qemu/${sourceImage}.qcow2' -var 'ssh_password=${SLES15_INITIAL_ROOT_PASSWORD}' -var 'artifactory_user=${ARTIFACTORY_USER}' -var 'artifactory_token=${ARTIFACTORY_TOKEN}' -var 'cpus=${NPROC}' -var 'memory=${NRAM}' -var 'artifact_version=${VERSION}'"
-                                sh 'packer init boxes/ncn-node-images/variables.pkr.hcl'
                                 publishCsmImages.build(arguments, 'boxes/ncn-node-images/')
                                 publishCsmImages.prepareArtifacts("${ARTIFACTS_DIRECTORY_CEPH}-qemu", env.VERSION)
                                 props = "build.number=${VERSION};build.url=${env.BUILD_URL};vcs.revision-short=${GIT_COMMIT[0..6]};build.source-artifact=${sourceImage}"

--- a/boxes/ncn-node-images/kubernetes/provisioners/common/install.sh
+++ b/boxes/ncn-node-images/kubernetes/provisioners/common/install.sh
@@ -102,7 +102,7 @@ modprobe overlay
 modprobe br_netfilter
 
 echo "Installing kubernetes python client"
-python3 -m pip install --ignore-installed PyYAML
+python3 -m pip install --ignore-installed 'PyYAML<6.0'
 #
 # CSM 1.2 shipped with 23.6.0, so we need equal to
 # or greater than that version


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1910

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
`packer init` was added to ensure we always have the right plugins installed, but running `packer init` in `parallel {}` Jenkins blocks proves to cause problems.

This change runs a single `packer init` at the beginning of the build, removing `packer init` from each layer.

This problem has been encountered following the merge of #464 , but it was not encountered during #464's builds since that PR build a base layer and invoked `packer init` then. The subsequent `packer init` calls never had to do anything since the plugins were already installed. This problem is coming about quite often now that we begin with the ncn-node-image layer and run `packer init` in parallel.


### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
